### PR TITLE
feat(infra): conectar ao postgresql e criar a tabela `users`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 APP_ENV = "development"
 APP_HOST = "127.0.0.1"
 APP_PORT = "4000"
+DATABASE_URL = "postgres://postgres:postgres@127.0.0.1:5432/fincheck"

--- a/node-pg-migrate.config.ts
+++ b/node-pg-migrate.config.ts
@@ -1,0 +1,4 @@
+export default {
+  'migration-file-language': 'ts',
+  'migrations-dir': 'src/infra/database/migrations'
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "lint:commit": "commitlint --edit $1",
     "lint:check": "oxlint",
     "lint:fix": "oxlint --fix",
+    "migration:create": "node-pg-migrate --config-file node-pg-migrate.config.ts create",
+    "migration:down": "dotenv -e .env -- node-pg-migrate --config-file node-pg-migrate.config.ts down",
+    "migration:up": "dotenv -e .env -- node-pg-migrate --config-file node-pg-migrate.config.ts up",
     "start:dev": "tsx watch --env-file .env src/main/main.ts",
     "test": "dotenv -e .env.test -- vitest run --dir tests",
     "test:watch": "dotenv -e .env.test -- vitest --dir tests"

--- a/src/common/core/config.ts
+++ b/src/common/core/config.ts
@@ -3,7 +3,11 @@ import { z } from 'zod'
 const CONFIG_SCHEMA = z.object({
   APP_ENV: z.enum(['development', 'production', 'staging', 'test']),
   APP_HOST: z.ipv4({ error: 'Must be a valid IPv4 address' }),
-  APP_PORT: z.coerce.number({ error: 'Must be a number greater or equal to 0' })
+  APP_PORT: z.coerce.number({ error: 'Must be a number greater or equal to 0' }),
+  DATABASE_URL: z.url({
+    error: 'Must be a valid postgres:// connection string',
+    protocol: /^postgres(ql)?$/
+  })
 })
 
 type ConfigValues = z.infer<typeof CONFIG_SCHEMA>
@@ -16,6 +20,12 @@ export class Configuration {
       env: this.values.APP_ENV,
       host: this.values.APP_HOST,
       port: this.values.APP_PORT
+    }
+  }
+
+  public get database() {
+    return {
+      url: this.values.DATABASE_URL
     }
   }
 

--- a/src/infra/database/connection.ts
+++ b/src/infra/database/connection.ts
@@ -1,0 +1,31 @@
+import { DateTime } from 'luxon'
+import { Pool, type QueryResultRow, types } from 'pg'
+import { type Configuration } from '@common/core/config'
+
+const TIMESTAMPTZ_OID = 1184
+
+types.setTypeParser(
+  TIMESTAMPTZ_OID,
+  (value: string): DateTime => DateTime.fromSQL(value, { setZone: true }).toUTC()
+)
+
+export class DatabaseConnection {
+  private constructor(private readonly pool: Pool) {}
+
+  public async query<T extends QueryResultRow>(
+    statement: string,
+    parameters: readonly unknown[] = []
+  ): Promise<T[]> {
+    const result = await this.pool.query<T>(statement, [...parameters])
+
+    return result.rows
+  }
+
+  public async disconnect(): Promise<void> {
+    await this.pool.end()
+  }
+
+  public static create(config: Configuration): DatabaseConnection {
+    return new DatabaseConnection(new Pool({ connectionString: config.database.url }))
+  }
+}

--- a/src/infra/database/migrations/1787058037086_create-users-table.ts
+++ b/src/infra/database/migrations/1787058037086_create-users-table.ts
@@ -1,0 +1,35 @@
+import type { MigrationBuilder } from 'node-pg-migrate'
+
+const TABLE = 'users'
+const EMAIL_UNIQUE_INDEX = 'users_email_unique_idx'
+const EMAIL_UNIQUE_EXPRESSION = 'LOWER(email)'
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.createTable(
+    TABLE,
+    {
+      id: { type: 'char(26)', notNull: true },
+      first_name: { type: 'varchar(50)', notNull: true },
+      last_name: { type: 'varchar(50)', notNull: true },
+      email: { type: 'varchar(254)', notNull: true },
+      password_hash: { type: 'text', notNull: true },
+      created_at: { type: 'timestamptz', notNull: true },
+      updated_at: { type: 'timestamptz', notNull: true }
+    },
+    {
+      constraints: {
+        primaryKey: 'id'
+      }
+    }
+  )
+
+  pgm.createIndex(TABLE, EMAIL_UNIQUE_EXPRESSION, {
+    name: EMAIL_UNIQUE_INDEX,
+    unique: true
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropIndex(TABLE, EMAIL_UNIQUE_EXPRESSION, { name: EMAIL_UNIQUE_INDEX })
+  pgm.dropTable(TABLE)
+}


### PR DESCRIPTION
Fecha BAC-25.

Estabelece o banco da entrega: `Configuration` passa a ler a string de conexão, nasce a conexão com o pool do `pg` e o mecanismo de migrações, e a tabela `users` ganha o índice que garante a unicidade case-insensitive do e-mail.

## O que muda

- `src/common/core/config.ts` — `DATABASE_URL` no `CONFIG_SCHEMA` e getter `database`, no mesmo estilo do getter `app`
- `.env.example` — `DATABASE_URL` declarada
- `src/infra/database/connection.ts` — `DatabaseConnection` com pool do `pg`, `query()` e `disconnect()` (que BAC-32 vai chamar no `stop()` da API). Registra um parser para o OID `1184` devolvendo `DateTime` em UTC, para que o `Date` nativo não entre pela borda do banco (DEC-15)
- `node-pg-migrate.config.ts` + scripts `migration:up`, `migration:down` e `migration:create`
- Migração inicial criando `users`, `users_pkey` e `users_email_unique_idx`

## Verificação contra um PostgreSQL real

```
Indexes:
    "users_pkey" PRIMARY KEY, btree (id)
    "users_email_unique_idx" UNIQUE, btree (lower(email::text))
```

Comportamento conferido em container descartável:

- `created_at` volta como `DateTime` do Luxon com `zoneName: UTC` e `instanceof Date === false` — inclusive com a sessão em `America/Sao_Paulo`
- E-mail persistido com a grafia original (`Tifa.Lockhart@Gmail.com`)
- Inserir `TIFA.LOCKHART@GMAIL.COM` por cima falha com **`23505` na constraint `users_email_unique_idx`** — exatamente o par que a DEC-02 usa para traduzir em `409` na BAC-30
- `migration:down` seguido de `migration:up` roda limpo

## Desvio da TechSpec

O regex de protocolo aceita `postgres` **e** `postgresql`: o `getConnectionUri()` do `@testcontainers/postgresql` devolve `postgresql://`, e um `/^postgres$/` estrito quebraria a injeção do orquestrador na BAC-33.

## Notas para as tarefas seguintes

- `.env.test` deliberadamente não tem `DATABASE_URL` — o orquestrador (BAC-33) injeta. Qualquer teste que chame `Configuration.from(process.env)` antes disso falha na validação
- `DatabaseConnection.query()` é single-statement: string com múltiplos comandos faz o `pg` devolver array de resultados e `result.rows` vira `undefined`

## Pilha

Base: `BAC-24`. Mergear depois dele e antes de `BAC-26`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)