### PR TITLE
feat(domain): criar a entidade `user` e o contrato `users-repository`

### DIFF
--- a/src/domain/entities/user.ts
+++ b/src/domain/entities/user.ts
@@ -1,0 +1,62 @@
+import { DateTime } from 'luxon'
+import { ulid } from 'ulid'
+
+type UserAttributes = Readonly<{
+  id: string
+  firstName: string
+  lastName: string
+  email: string
+  passwordHash: string
+  createdAt: DateTime
+  updatedAt: DateTime
+}>
+
+export type NewUserAttributes = Readonly<{
+  firstName: string
+  lastName: string
+  email: string
+  passwordHash: string
+}>
+
+export class User {
+  private constructor(private readonly attributes: UserAttributes) {}
+
+  public get id(): string {
+    return this.attributes.id
+  }
+
+  public get firstName(): string {
+    return this.attributes.firstName
+  }
+
+  public get lastName(): string {
+    return this.attributes.lastName
+  }
+
+  public get email(): string {
+    return this.attributes.email
+  }
+
+  public get passwordHash(): string {
+    return this.attributes.passwordHash
+  }
+
+  public get createdAt(): DateTime {
+    return this.attributes.createdAt
+  }
+
+  public get updatedAt(): DateTime {
+    return this.attributes.updatedAt
+  }
+
+  public static create(attributes: NewUserAttributes): User {
+    const createdAt = DateTime.utc()
+
+    return new User({
+      ...attributes,
+      createdAt,
+      id: ulid(),
+      updatedAt: createdAt
+    })
+  }
+}

--- a/src/domain/repositories/users-repository.ts
+++ b/src/domain/repositories/users-repository.ts
@@ -1,0 +1,5 @@
+import { type User } from '@domain/entities/user'
+
+export interface UsersRepository {
+  create(user: User): Promise<void>
+}

--- a/tests/unit/domain/entities/user.spec.ts
+++ b/tests/unit/domain/entities/user.spec.ts
@@ -1,0 +1,66 @@
+import { DateTime } from 'luxon'
+import { ulid } from 'ulid'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { User } from '@domain/entities/user'
+
+vi.mock('ulid')
+
+const IDENTIFIER = '01M063ET5G1JAXFBKESMJKJ9G3'
+const CREATED_AT = DateTime.utc(2026, 8, 18, 12, 30, 45, 123) as DateTime<true>
+const PASSWORD_HASH = '$argon2id$v=19$m=19456,t=2,p=1$c29tZXNhbHQ$c29tZWhhc2g'
+const PLAIN_TEXT_PASSWORD = 'cavalo bateria grampo correto'
+
+function makeSUT() {
+  const ulidSpy = vi.mocked(ulid).mockReturnValue(IDENTIFIER)
+  const utcSpy = vi.spyOn(DateTime, 'utc').mockReturnValue(CREATED_AT)
+  const localSpy = vi.spyOn(DateTime, 'local')
+  const nowSpy = vi.spyOn(DateTime, 'now')
+  const attributes = {
+    email: 'Tifa.Lockhart@Gmail.com',
+    firstName: 'Tifa',
+    lastName: 'Lockhart',
+    passwordHash: PASSWORD_HASH
+  }
+
+  return { sut: User, attributes, localSpy, nowSpy, ulidSpy, utcSpy }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('User.create', () => {
+  test('Generates the identifier and the creation date, and keeps the password hash', () => {
+    // Arrange
+    const { sut, attributes, ulidSpy } = makeSUT()
+
+    // Act
+    const user = sut.create(attributes)
+
+    // Assert
+    expect(ulidSpy).toHaveBeenCalledOnce()
+    expect(user.id).toBe(IDENTIFIER)
+    expect(user.createdAt).toBe(CREATED_AT)
+    expect(user.updatedAt).toBe(user.createdAt)
+    expect(user.firstName).toBe('Tifa')
+    expect(user.lastName).toBe('Lockhart')
+    expect(user.email).toBe('Tifa.Lockhart@Gmail.com')
+    expect(user.passwordHash).toBe(PASSWORD_HASH)
+    expect(user).not.toHaveProperty('password')
+    expect(JSON.stringify(user)).not.toContain(PLAIN_TEXT_PASSWORD)
+  })
+
+  test('Stamps the creation date in UTC', () => {
+    // Arrange
+    const { sut, attributes, localSpy, nowSpy, utcSpy } = makeSUT()
+
+    // Act
+    const user = sut.create(attributes)
+
+    // Assert
+    expect(utcSpy).toHaveBeenCalledOnce()
+    expect(localSpy).not.toHaveBeenCalled()
+    expect(nowSpy).not.toHaveBeenCalled()
+    expect(user.createdAt.zoneName).toBe('UTC')
+  })
+})


### PR DESCRIPTION
Fecha BAC-26.

Nasce a camada de domínio. `User` é a pessoa cadastrada no Fincheck: identificador, nome, e-mail com a grafia original e o hash da senha — nunca a senha em texto puro.

## O que muda

- `src/domain/entities/user.ts` — entidade `User` com construtor privado sobre atributos `Readonly` e getters. `User.create()` gera o próprio ULID e o próprio `createdAt` via `DateTime.utc()`, derivando `updatedAt` do mesmo valor
- `src/domain/repositories/users-repository.ts` — `UsersRepository` com apenas `create(user: User): Promise<void>`. Sem métodos de busca ou paginação, que estão fora de escopo

O tipo de entrada `NewUserAttributes` aceita apenas `firstName`, `lastName`, `email` e `passwordHash`. A senha em texto puro não tem por onde entrar na entidade, e o e-mail é guardado exatamente como recebido.

## Por que identidade e data nascem dentro da entidade

Identidade e instante de criação são invariantes de `User` e não devem depender de quem a chama (DEC-16). O custo é que a entidade passa a ter duas fontes não determinísticas, resolvido nos testes fixando ambas.

## Testes

| ID | O que prova |
| -- | -- |
| TU-01 | Com `ulid` e `DateTime.utc` fixados, a entidade nasce com o ULID e a data esperados, `updatedAt` igual a `createdAt`, e a senha em texto puro é inacessível |
| TU-02 | A criação é carimbada em UTC — o teste espia `DateTime.local` e `DateTime.now` e afirma que **não** são chamados, além de checar `createdAt.zoneName === 'UTC'` |

O ULID é fixado com `vi.mock('ulid')` e não com `vi.spyOn`, porque `vi.spyOn` sobre export de módulo ESM falha com `Module namespace is not configurable in ESM` (DEC-16). O Luxon aceita `vi.spyOn(DateTime, 'utc')` por ser método estático de classe. `vi.restoreAllMocks()` em `beforeEach` mantém os testes independentes de ordem.

## Pilha

Base: `BAC-25`. Mergear depois dele e antes de `BAC-28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)