### PR TITLE
feat(infra): declarar o `password-hasher` e implementá-lo com argon2id

### DIFF
--- a/src/application/interfaces/security/password-hasher.ts
+++ b/src/application/interfaces/security/password-hasher.ts
@@ -1,0 +1,3 @@
+export interface PasswordHasher {
+  hash(plainText: string): Promise<string>
+}

--- a/src/infra/security/argon2-password-hasher.ts
+++ b/src/infra/security/argon2-password-hasher.ts
@@ -1,0 +1,17 @@
+import { Algorithm, hash } from '@node-rs/argon2'
+import { type PasswordHasher } from '@application/interfaces/security/password-hasher'
+
+const MEMORY_COST_IN_KIB = 19456
+const PARALLELISM = 1
+const TIME_COST = 2
+
+export class Argon2PasswordHasher implements PasswordHasher {
+  public async hash(plainText: string): Promise<string> {
+    return hash(plainText, {
+      algorithm: Algorithm.Argon2id,
+      memoryCost: MEMORY_COST_IN_KIB,
+      parallelism: PARALLELISM,
+      timeCost: TIME_COST
+    })
+  }
+}

--- a/tests/unit/infra/security/argon2-password-hasher.spec.ts
+++ b/tests/unit/infra/security/argon2-password-hasher.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest'
+import { Argon2PasswordHasher } from '@infra/security/argon2-password-hasher'
+
+function makeSUT() {
+  const sut = new Argon2PasswordHasher()
+
+  return { sut }
+}
+
+describe('Argon2PasswordHasher', () => {
+  test('Produce a PHC string of Argon2id with the OWASP parameters', async () => {
+    // Arrange
+    const { sut } = makeSUT()
+    const plainText = 'cavalo bateria grampo correto'
+
+    // Act
+    const output = await sut.hash(plainText)
+
+    // Assert
+    expect(output.startsWith('$argon2id$')).toBe(true)
+    expect(output).toMatch(/^\$argon2id\$v=19\$m=19456,t=2,p=1\$/)
+    expect(output).not.toContain(plainText)
+  })
+
+  test('Produce a different hash on every call for the same password', async () => {
+    // Arrange
+    const { sut } = makeSUT()
+    const plainText = 'cavalo bateria grampo correto'
+
+    // Act
+    const first = await sut.hash(plainText)
+    const second = await sut.hash(plainText)
+
+    // Assert
+    expect(first).not.toEqual(second)
+    expect(first.startsWith('$argon2id$')).toBe(true)
+    expect(second.startsWith('$argon2id$')).toBe(true)
+  })
+})


### PR DESCRIPTION
Fecha BAC-28.

A senha não pode ficar legível em nenhum registro do sistema. Entra o contrato que o caso de uso enxerga e a implementação com Argon2id.

## O que muda

- `src/application/interfaces/security/password-hasher.ts` — `PasswordHasher` com apenas `hash(plainText: string): Promise<string>`. Sem `verify`/`compare`: verificação de senha só passa a existir com o login e está explicitamente fora de escopo
- `src/infra/security/argon2-password-hasher.ts` — `Argon2PasswordHasher` usando `@node-rs/argon2`

Parâmetros nos mínimos recomendados pela OWASP, todos passados explicitamente porque os defaults do pacote (4096 KiB, t=3) não batem com a recomendação:

| Parâmetro | Valor |
| -- | -- |
| `algorithm` | `Argon2id` |
| `memoryCost` | `19456` KiB (19 MiB) |
| `timeCost` | `2` |
| `parallelism` | `1` |

## Testes

| ID | O que prova |
| -- | -- |
| TU-05 | A saída casa com `/^\$argon2id\$v=19\$m=19456,t=2,p=1\$/` e não contém a senha em texto puro |
| TU-05 | Duas chamadas com a mesma senha produzem hashes distintos, porque o salt é sorteado por chamada |

A asserção sobre a string PHC verifica os custos no próprio hash, então uma regressão nos parâmetros quebra o teste em vez de passar silenciosamente.

## Versão

`@node-rs/argon2` está em `2.0.2`, e não na `2.1.0` da TechSpec, porque o `.npmrc` impõe `min-release-age = 7` e a `2.1.0` saiu há 5 dias. A API de `hash` e `Options` é idêntica, então nenhuma adaptação foi necessária e DEC-04 e DEC-05 seguem valendo. O desvio foi aplicado em BAC-24.

## Pilha

Base: `BAC-26`. É o topo da onda 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)