### PR TITLE
feat(common): ampliar o `problem` e tratar corpo de requisição malformado

### DIFF
--- a/src/common/http/problem.ts
+++ b/src/common/http/problem.ts
@@ -4,8 +4,9 @@ import { StatusCode } from '@common/http/statuses'
 type Details = Readonly<{
   title: string
   detail: string
-  status: StatusCode
 }>
+
+type ProblemDetails = Details & Readonly<{ status: StatusCode }>
 
 export class Problem extends Error {
   private readonly title: string
@@ -14,7 +15,7 @@ export class Problem extends Error {
   private readonly errors: Map<string, string>
   private instance?: string
 
-  private constructor(details: Details) {
+  private constructor(details: ProblemDetails) {
     super()
 
     this.name = 'Problem'
@@ -40,6 +41,14 @@ export class Problem extends Error {
       instance: this.instance,
       ...(errors.length > 0 ? { errors } : {})
     }
+  }
+
+  public static badRequest(details: Details): Problem {
+    return new Problem({ ...details, status: StatusCode.BadRequest })
+  }
+
+  public static conflict(details: Details): Problem {
+    return new Problem({ ...details, status: StatusCode.Conflict })
   }
 
   public static fromZod(error: ZodError): Problem {

--- a/src/common/http/statuses.ts
+++ b/src/common/http/statuses.ts
@@ -1,4 +1,5 @@
 export enum StatusCode {
   BadRequest = 400,
+  Conflict = 409,
   InternalServerError = 500
 }

--- a/src/main/plugins/problem.ts
+++ b/src/main/plugins/problem.ts
@@ -2,11 +2,31 @@ import { type FastifyRequest, type FastifyReply } from 'fastify'
 import { ZodError } from 'zod'
 import { Problem } from '@common/http/problem'
 
+const MALFORMED_BODY_CODES = new Set([
+  'FST_ERR_CTP_EMPTY_JSON_BODY',
+  'FST_ERR_CTP_INVALID_CONTENT_LENGTH',
+  'FST_ERR_CTP_INVALID_JSON_BODY',
+  'FST_ERR_CTP_INVALID_MEDIA_TYPE'
+])
+
+function hasMalformedBody(error: Error): boolean {
+  const code = (error as { code?: unknown }).code
+
+  return typeof code === 'string' && MALFORMED_BODY_CODES.has(code)
+}
+
 export function problem(error: Error, request: FastifyRequest, reply: FastifyReply) {
   let response = Problem.internal()
 
-  if (error instanceof ZodError) {
+  if (error instanceof Problem) {
+    response = error
+  } else if (error instanceof ZodError) {
     response = Problem.fromZod(error)
+  } else if (hasMalformedBody(error)) {
+    response = Problem.badRequest({
+      title: 'Malformed request body',
+      detail: 'The request body is absent or could not be parsed as JSON'
+    })
   }
 
   response.setInstance(request.url)

--- a/tests/unit/common/http/problem.spec.ts
+++ b/tests/unit/common/http/problem.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'vitest'
+import { Problem } from '@common/http/problem'
+import { StatusCode } from '@common/http/statuses'
+
+function makeSUT() {
+  const sut = Problem
+
+  return { sut }
+}
+
+describe('Problem', () => {
+  describe('badRequest', () => {
+    test('Build a problem carrying the bad request status', () => {
+      // Arrange
+      const { sut } = makeSUT()
+      const details = {
+        title: 'Malformed request body',
+        detail: 'The request body is absent or could not be parsed as JSON'
+      }
+
+      // Act
+      const output = sut.badRequest(details)
+
+      // Assert
+      expect(output).toBeInstanceOf(Problem)
+      expect(output).toBeInstanceOf(Error)
+      expect(output.name).toEqual('Problem')
+      expect(output.status).toEqual(StatusCode.BadRequest)
+      expect(output.status).toEqual(400)
+    })
+
+    test('Serialize the given title and detail without an errors list', () => {
+      // Arrange
+      const { sut } = makeSUT()
+      const details = {
+        title: 'Malformed request body',
+        detail: 'The request body is absent or could not be parsed as JSON'
+      }
+
+      // Act
+      const output = sut.badRequest(details).serialize()
+
+      // Assert
+      expect(output).toEqual({
+        title: 'Malformed request body',
+        detail: 'The request body is absent or could not be parsed as JSON',
+        instance: undefined
+      })
+      expect(output).not.toHaveProperty('errors')
+    })
+
+    test('Serialize the instance set by the caller', () => {
+      // Arrange
+      const { sut } = makeSUT()
+      const problem = sut.badRequest({
+        title: 'Malformed request body',
+        detail: 'The request body is absent or could not be parsed as JSON'
+      })
+
+      // Act
+      problem.setInstance('/v1/users')
+      const output = problem.serialize()
+
+      // Assert
+      expect(output.instance).toEqual('/v1/users')
+    })
+  })
+
+  describe('conflict', () => {
+    test('Build a problem carrying the conflict status', () => {
+      // Arrange
+      const { sut } = makeSUT()
+      const details = {
+        title: 'Email already in use',
+        detail: 'An account with the given email address already exists'
+      }
+
+      // Act
+      const output = sut.conflict(details)
+
+      // Assert
+      expect(output).toBeInstanceOf(Problem)
+      expect(output).toBeInstanceOf(Error)
+      expect(output.name).toEqual('Problem')
+      expect(output.status).toEqual(StatusCode.Conflict)
+      expect(output.status).toEqual(409)
+    })
+
+    test('Serialize the given title and detail without an errors list', () => {
+      // Arrange
+      const { sut } = makeSUT()
+      const details = {
+        title: 'Email already in use',
+        detail: 'An account with the given email address already exists'
+      }
+
+      // Act
+      const output = sut.conflict(details).serialize()
+
+      // Assert
+      expect(output).toEqual({
+        title: 'Email already in use',
+        detail: 'An account with the given email address already exists',
+        instance: undefined
+      })
+      expect(output).not.toHaveProperty('errors')
+    })
+  })
+
+  test('Keep every built problem independent from the others', () => {
+    // Arrange
+    const { sut } = makeSUT()
+
+    // Act
+    const first = sut.badRequest({ title: 'First', detail: 'First detail' })
+    const second = sut.conflict({ title: 'Second', detail: 'Second detail' })
+    first.setInstance('/v1/users')
+
+    // Assert
+    expect(first.status).toEqual(StatusCode.BadRequest)
+    expect(second.status).toEqual(StatusCode.Conflict)
+    expect(second.serialize().instance).toBeUndefined()
+  })
+})

--- a/tests/unit/main/plugins/problem.spec.ts
+++ b/tests/unit/main/plugins/problem.spec.ts
@@ -1,0 +1,147 @@
+import { errorCodes, type FastifyReply, type FastifyRequest } from 'fastify'
+import { describe, expect, test, vi } from 'vitest'
+import { z, ZodError } from 'zod'
+import { Problem } from '@common/http/problem'
+import { StatusCode } from '@common/http/statuses'
+import { problem } from '@main/plugins/problem'
+
+function makeSUT() {
+  const reply = {
+    code: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis()
+  }
+  const request = { url: '/v1/users' } as FastifyRequest
+
+  return {
+    sut: problem,
+    reply: reply as unknown as FastifyReply,
+    replySpies: reply,
+    request
+  }
+}
+
+function makeZodError(): ZodError {
+  const schema = z.object({ email: z.string() })
+  const result = schema.safeParse({})
+
+  return result.error as ZodError
+}
+
+describe('problem', () => {
+  test('Answer an unknown error as an internal server error', () => {
+    // Arrange
+    const { sut, reply, replySpies, request } = makeSUT()
+    const error = new Error('Something went wrong')
+
+    // Act
+    sut(error, request, reply)
+
+    // Assert
+    expect(replySpies.code).toHaveBeenCalledWith(StatusCode.InternalServerError)
+    expect(replySpies.send).toHaveBeenCalledWith({
+      title: 'Internal Server Error',
+      detail: 'An unknown error prevented the server from responding your request',
+      instance: '/v1/users'
+    })
+  })
+
+  test('Answer an error carrying an unrelated code as an internal server error', () => {
+    // Arrange
+    const { sut, reply, replySpies, request } = makeSUT()
+    const error = Object.assign(new Error('aborted'), { code: 'ECONNRESET' })
+
+    // Act
+    sut(error, request, reply)
+
+    // Assert
+    expect(replySpies.code).toHaveBeenCalledWith(StatusCode.InternalServerError)
+  })
+
+  test('Answer a validation error with the problem built from the Zod issues', () => {
+    // Arrange
+    const { sut, reply, replySpies, request } = makeSUT()
+    const error = makeZodError()
+
+    // Act
+    sut(error, request, reply)
+
+    // Assert
+    expect(replySpies.code).toHaveBeenCalledWith(StatusCode.BadRequest)
+    expect(replySpies.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Request validation failed',
+        errors: [expect.objectContaining({ pointer: '#/email' })]
+      })
+    )
+  })
+
+  test.each([
+    ['FST_ERR_CTP_EMPTY_JSON_BODY', new errorCodes.FST_ERR_CTP_EMPTY_JSON_BODY()],
+    ['FST_ERR_CTP_INVALID_JSON_BODY', new errorCodes.FST_ERR_CTP_INVALID_JSON_BODY()],
+    ['FST_ERR_CTP_INVALID_MEDIA_TYPE', new errorCodes.FST_ERR_CTP_INVALID_MEDIA_TYPE()],
+    ['FST_ERR_CTP_INVALID_CONTENT_LENGTH', new errorCodes.FST_ERR_CTP_INVALID_CONTENT_LENGTH()]
+  ])('Answer %s as a bad request', (_code, error) => {
+    // Arrange
+    const { sut, reply, replySpies, request } = makeSUT()
+
+    // Act
+    sut(error, request, reply)
+
+    // Assert
+    expect(replySpies.code).toHaveBeenCalledWith(StatusCode.BadRequest)
+    expect(replySpies.send).toHaveBeenCalledWith({
+      title: 'Malformed request body',
+      detail: 'The request body is absent or could not be parsed as JSON',
+      instance: '/v1/users'
+    })
+  })
+
+  test('Answer a body parse error with a bad request instead of the status of Fastify', () => {
+    // Arrange
+    const { sut, reply, replySpies, request } = makeSUT()
+    const error = new errorCodes.FST_ERR_CTP_INVALID_MEDIA_TYPE()
+
+    // Act
+    sut(error, request, reply)
+
+    // Assert
+    expect(error.statusCode).toEqual(415)
+    expect(replySpies.code).toHaveBeenCalledWith(400)
+    expect(replySpies.code).not.toHaveBeenCalledWith(415)
+  })
+
+  test('Preserve a problem raised by a lower layer', () => {
+    // Arrange
+    const { sut, reply, replySpies, request } = makeSUT()
+    const error = Problem.conflict({
+      title: 'Email already in use',
+      detail: 'An account with the given email address already exists'
+    })
+
+    // Act
+    sut(error, request, reply)
+
+    // Assert
+    expect(replySpies.code).toHaveBeenCalledWith(StatusCode.Conflict)
+    expect(replySpies.send).toHaveBeenCalledWith({
+      title: 'Email already in use',
+      detail: 'An account with the given email address already exists',
+      instance: '/v1/users'
+    })
+  })
+
+  test('Stamp the requested url as the instance of the problem', () => {
+    // Arrange
+    const { sut, reply, replySpies } = makeSUT()
+    const request = { url: '/v1/users?page=2' } as FastifyRequest
+    const error = new Error('Something went wrong')
+
+    // Act
+    sut(error, request, reply)
+
+    // Assert
+    expect(replySpies.send).toHaveBeenCalledWith(
+      expect.objectContaining({ instance: '/v1/users?page=2' })
+    )
+  })
+})


### PR DESCRIPTION
Fecha BAC-27.

O `Problem` só sabia montar erro de validação do Zod e erro interno. Como `code-standards.md` proíbe erros customizados, o cadastro depende de fábricas novas na classe existente. Junto vem a correção de dois comportamentos errados do handler global.

## O que muda

- `src/common/http/statuses.ts` — `Conflict = 409`
- `src/common/http/problem.ts` — `Problem.badRequest(details)` e `Problem.conflict(details)`. O tipo público ficou exatamente como a TechSpec declara (`Details = { title, detail }`), com um `ProblemDetails = Details & { status }` interno para o construtor privado
- `src/main/plugins/problem.ts` — cadeia de classificação antes do fallback `internal()`

## Duas correções no handler

**1. Corpo malformado virava `500`.** Corpo ausente ou JSON quebrado é falha do cliente. Os códigos tratados foram descobertos lendo `node_modules/fastify/lib/errors.js` e `lib/content-type-parser.js`, e confirmados com um servidor de sondagem descartável que logava `error.code` de um `setErrorHandler` real:

| Código | Status nativo | Gatilho reproduzido |
| -- | -- | -- |
| `FST_ERR_CTP_EMPTY_JSON_BODY` | 400 | POST `application/json` sem corpo |
| `FST_ERR_CTP_INVALID_JSON_BODY` | 400 | POST com JSON truncado |
| `FST_ERR_CTP_INVALID_MEDIA_TYPE` | 415 | POST `application/xml` |
| `FST_ERR_CTP_INVALID_CONTENT_LENGTH` | 400 | só verificado no código-fonte |

**2. Um `Problem` de camada inferior era engolido.** O handler convertia qualquer erro em `Problem.internal()`, descartando o status de um `Problem` já construído. Isso não estava no escopo declarado da tarefa, mas quebraria a BAC-30: o `409` que o repositório vai disparar ao traduzir o `23505` chegaria ao cliente como `500`. Agora há curto-circuito em `error instanceof Problem`, coberto por teste.

## Dois pontos que merecem sua decisão

- **`FST_ERR_CTP_INVALID_MEDIA_TYPE` responde `400`, não `415`.** A tabela de respostas da TechSpec para `POST /v1/users` não tem linha de `415`, então mantive o contrato como está escrito. Se você preferir preservar a semântica HTTP e devolver `415` para tipo de mídia não suportado, é uma linha de mudança — mas altera o contrato do endpoint, então não fiz por conta própria.
- **`FST_ERR_CTP_INVALID_CONTENT_LENGTH` não foi reproduzível via cliente HTTP.** Corpo curto com `Content-Length` inflado faz o parser do Node abortar o socket antes, e o handler recebe `ECONNRESET`. O código foi incluído porque é levantado do mesmo caminho `done()` em `rawBody` que o `FST_ERR_CTP_EMPTY_JSON_BODY`, esse sim verificado ponta a ponta. O teste dele constrói o erro diretamente. O caso `ECONNRESET` segue caindo em `500`, o que é adequado: o cliente já foi embora e não houve falha de parse.

Um `POST` sem corpo e sem content-type não é erro no Fastify — chega ao handler com `body` indefinido e será pego pelo schema do Zod na BAC-31.

## Pilha

Base: `BAC-28`. Mergear depois dele e antes de `BAC-29`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)