### PR TITLE
feat(application): implementar o caso de uso `create-user` e os dublês de teste

### DIFF
--- a/src/application/usecases/user/create-user.ts
+++ b/src/application/usecases/user/create-user.ts
@@ -1,0 +1,33 @@
+import { type PasswordHasher } from '@application/interfaces/security/password-hasher'
+import { User } from '@domain/entities/user'
+import { type UsersRepository } from '@domain/repositories/users-repository'
+
+export type CreateUserInput = {
+  firstName: string
+  lastName: string
+  email: string
+  password: string
+}
+
+export interface CreateUser {
+  execute(input: CreateUserInput): Promise<void>
+}
+
+export class CreateUserUseCase implements CreateUser {
+  public constructor(
+    private readonly usersRepository: UsersRepository,
+    private readonly passwordHasher: PasswordHasher
+  ) {}
+
+  public async execute(input: CreateUserInput): Promise<void> {
+    const passwordHash = await this.passwordHasher.hash(input.password)
+    const user = User.create({
+      email: input.email,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      passwordHash
+    })
+
+    await this.usersRepository.create(user)
+  }
+}

--- a/tests/mocks/fake-password-hasher.ts
+++ b/tests/mocks/fake-password-hasher.ts
@@ -1,0 +1,11 @@
+import { type PasswordHasher } from '@application/interfaces/security/password-hasher'
+
+const PREFIX = 'fake-hash'
+
+export class FakePasswordHasher implements PasswordHasher {
+  public hash(plainText: string): Promise<string> {
+    const digest = Buffer.from(plainText, 'utf8').toString('base64url')
+
+    return Promise.resolve(`${PREFIX}:${digest}`)
+  }
+}

--- a/tests/mocks/in-memory-users-repository.ts
+++ b/tests/mocks/in-memory-users-repository.ts
@@ -1,0 +1,12 @@
+import { type User } from '@domain/entities/user'
+import { type UsersRepository } from '@domain/repositories/users-repository'
+
+export class InMemoryUsersRepository implements UsersRepository {
+  public readonly users: User[] = []
+
+  public create(user: User): Promise<void> {
+    this.users.push(user)
+
+    return Promise.resolve()
+  }
+}

--- a/tests/unit/application/usecases/user/create-user.spec.ts
+++ b/tests/unit/application/usecases/user/create-user.spec.ts
@@ -1,0 +1,78 @@
+import { DateTime } from 'luxon'
+import { ulid } from 'ulid'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { CreateUserUseCase } from '@application/usecases/user/create-user'
+import { User } from '@domain/entities/user'
+import { FakePasswordHasher } from '../../../../mocks/fake-password-hasher'
+import { InMemoryUsersRepository } from '../../../../mocks/in-memory-users-repository'
+
+vi.mock('ulid')
+
+const IDENTIFIER = '01M063ET5G1JAXFBKESMJKJ9G3'
+const CREATED_AT = DateTime.utc(2026, 8, 18, 12, 30, 45, 123) as DateTime<true>
+const PLAIN_TEXT_PASSWORD = 'cavalo bateria grampo correto'
+
+function makeSUT() {
+  const ulidSpy = vi.mocked(ulid).mockReturnValue(IDENTIFIER)
+  const utcSpy = vi.spyOn(DateTime, 'utc').mockReturnValue(CREATED_AT)
+  const passwordHasher = new FakePasswordHasher()
+  const usersRepository = new InMemoryUsersRepository()
+  const sut = new CreateUserUseCase(usersRepository, passwordHasher)
+  const input = {
+    email: 'Tifa.Lockhart@Gmail.com',
+    firstName: 'Tifa',
+    lastName: 'Lockhart',
+    password: PLAIN_TEXT_PASSWORD
+  }
+
+  return { sut, input, passwordHasher, ulidSpy, usersRepository, utcSpy }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('CreateUser.execute', () => {
+  test('Delegates the hashing and assembles the same user on every run', async () => {
+    // Arrange
+    const { sut, input, passwordHasher, usersRepository } = makeSUT()
+    const expectedHash = await passwordHasher.hash(PLAIN_TEXT_PASSWORD)
+    const hashSpy = vi.spyOn(passwordHasher, 'hash')
+
+    // Act
+    await sut.execute(input)
+    await sut.execute(input)
+    const [firstUser, secondUser] = usersRepository.users
+
+    // Assert
+    expect(hashSpy).toHaveBeenCalledTimes(2)
+    expect(hashSpy).toHaveBeenCalledWith(PLAIN_TEXT_PASSWORD)
+    expect(firstUser).toEqual(secondUser)
+    expect(firstUser.id).toBe(IDENTIFIER)
+    expect(firstUser.createdAt).toBe(CREATED_AT)
+    expect(firstUser.updatedAt).toBe(firstUser.createdAt)
+    expect(firstUser.firstName).toBe('Tifa')
+    expect(firstUser.lastName).toBe('Lockhart')
+    expect(firstUser.email).toBe('Tifa.Lockhart@Gmail.com')
+    expect(firstUser.passwordHash).toBe(expectedHash)
+  })
+
+  test('Hands a single user to the repository without the plain text password', async () => {
+    // Arrange
+    const { sut, input, usersRepository } = makeSUT()
+    const createSpy = vi.spyOn(usersRepository, 'create')
+
+    // Act
+    const output = await sut.execute(input)
+    const [user] = usersRepository.users
+
+    // Assert
+    expect(output).toBeUndefined()
+    expect(createSpy).toHaveBeenCalledOnce()
+    expect(usersRepository.users).toHaveLength(1)
+    expect(user).toBeInstanceOf(User)
+    expect(user.passwordHash).not.toBe(PLAIN_TEXT_PASSWORD)
+    expect(user.passwordHash).not.toContain(PLAIN_TEXT_PASSWORD)
+    expect(JSON.stringify(user)).not.toContain(PLAIN_TEXT_PASSWORD)
+  })
+})


### PR DESCRIPTION
Fecha BAC-29.

O caso de uso amarra hash e persistência: gera o hash da senha, monta a entidade `User` e a entrega ao repositório.

## O que muda

- `src/application/usecases/user/create-user.ts` — `CreateUserInput`, a interface `CreateUser` e a classe `CreateUserUseCase(usersRepository, passwordHasher)`
- `tests/mocks/in-memory-users-repository.ts` — guarda os usuários em `users: User[]`, inspecionável pelos testes
- `tests/mocks/fake-password-hasher.ts` — devolve `fake-hash:<base64url(plainText)>`

O que o caso de uso **não** faz, e é deliberado: não emite sessão, não emite token, não envia e-mail (CA-04 e CA-05), e não consulta o banco antes de inserir para detectar e-mail duplicado — isso é do repositório na BAC-30, que deixa o `INSERT` falhar e traduz o `23505` (DEC-02). Sem `try-catch`, que só é permitido na `infra`.

## Testes

| ID | O que prova |
| -- | -- |
| TU-03 | Com `ulid` e `DateTime.utc` fixados, duas execuções seguidas produzem entidades iguais (`toEqual`), com o hash devolvido pelo hasher |
| TU-04 | O repositório recebe exatamente um usuário, `execute` devolve `undefined`, e a senha em texto puro não aparece em lugar nenhum |

O TU-04 verifica `JSON.stringify(user)` inteiro, e não só `passwordHash` — isso alcança o objeto `attributes` privado da entidade, então nenhum campo pode vazar a senha silenciosamente. O `FakePasswordHasher` usa base64url justamente para que sua saída não contenha a senha como substring; com um dublê ingênuo (ex.: `hashed:<senha>`) essa asserção passaria por acidente.

## Nota de nomenclatura para a BAC-32

A interface ocupa o nome `CreateUser`, então a classe concreta é `CreateUserUseCase`. O wiring deve instanciar `new CreateUserUseCase(usersRepository, passwordHasher)`, nessa ordem de parâmetros.

Os dublês são importados por caminho relativo: os aliases do `tsconfig.json` cobrem apenas `src/`, e `tests/mocks` não tem alias.

## Pilha

Base: `BAC-27`. É o topo da onda 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)