### PR TITLE
feat(infra): implementar o `postgres-users-repository` com tradução do erro 23505

### DIFF
--- a/src/infra/database/repositories/postgres-users-repository.ts
+++ b/src/infra/database/repositories/postgres-users-repository.ts
@@ -1,0 +1,48 @@
+import { DatabaseError, type QueryResultRow } from 'pg'
+import { Problem } from '@common/http/problem'
+import { type User } from '@domain/entities/user'
+import { type UsersRepository } from '@domain/repositories/users-repository'
+import { type DatabaseConnection } from '@infra/database/connection'
+
+const EMAIL_UNIQUE_INDEX = 'users_email_unique_idx'
+const UNIQUE_VIOLATION = '23505'
+
+const INSERT_USER = `
+  INSERT INTO users (id, first_name, last_name, email, password_hash, created_at, updated_at)
+  VALUES ($1, $2, $3, $4, $5, $6, $7)
+`
+
+function isEmailAlreadyRegistered(error: unknown): boolean {
+  return (
+    error instanceof DatabaseError &&
+    error.code === UNIQUE_VIOLATION &&
+    error.constraint === EMAIL_UNIQUE_INDEX
+  )
+}
+
+export class PostgresUsersRepository implements UsersRepository {
+  public constructor(private readonly connection: DatabaseConnection) {}
+
+  public async create(user: User): Promise<void> {
+    try {
+      await this.connection.query<QueryResultRow>(INSERT_USER, [
+        user.id,
+        user.firstName,
+        user.lastName,
+        user.email,
+        user.passwordHash,
+        user.createdAt.toISO(),
+        user.updatedAt.toISO()
+      ])
+    } catch (error) {
+      if (isEmailAlreadyRegistered(error)) {
+        throw Problem.conflict({
+          title: 'Email already in use',
+          detail: 'An account with the given email address already exists'
+        })
+      }
+
+      throw error
+    }
+  }
+}

--- a/tests/unit/infra/database/repositories/postgres-users-repository.spec.ts
+++ b/tests/unit/infra/database/repositories/postgres-users-repository.spec.ts
@@ -1,0 +1,159 @@
+import { DateTime } from 'luxon'
+import { DatabaseError } from 'pg'
+import { ulid } from 'ulid'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { Configuration } from '@common/core/config'
+import { Problem } from '@common/http/problem'
+import { StatusCode } from '@common/http/statuses'
+import { User } from '@domain/entities/user'
+import { DatabaseConnection } from '@infra/database/connection'
+import { PostgresUsersRepository } from '@infra/database/repositories/postgres-users-repository'
+
+vi.mock('ulid')
+
+const IDENTIFIER = '01M063ET5G1JAXFBKESMJKJ9G3'
+const CREATED_AT = DateTime.utc(2026, 8, 18, 12, 30, 45, 123) as DateTime<true>
+const ENVIRONMENT = {
+  APP_ENV: 'test',
+  APP_HOST: '0.0.0.0',
+  APP_PORT: '0',
+  DATABASE_URL: 'postgres://postgres:postgres@localhost:5432/fincheck'
+}
+
+function makeDatabaseError(code: string, constraint: string): DatabaseError {
+  const error = new DatabaseError('duplicate key value violates unique constraint', 128, 'error')
+
+  error.code = code
+  error.constraint = constraint
+
+  return error
+}
+
+async function makeSUT() {
+  vi.mocked(ulid).mockReturnValue(IDENTIFIER)
+  vi.spyOn(DateTime, 'utc').mockReturnValue(CREATED_AT)
+
+  const configuration = await Configuration.from(ENVIRONMENT)
+  const connection = DatabaseConnection.create(configuration)
+  const querySpy = vi.spyOn(connection, 'query').mockResolvedValue([])
+  const sut = new PostgresUsersRepository(connection)
+  const user = User.create({
+    email: 'Tifa.Lockhart@Gmail.com',
+    firstName: 'Tifa',
+    lastName: 'Lockhart',
+    passwordHash: '$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA'
+  })
+
+  return { sut, connection, querySpy, user }
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('PostgresUsersRepository.create', () => {
+  test('Persist every column through a parameterized statement', async () => {
+    // Arrange
+    const { sut, querySpy, user } = await makeSUT()
+
+    // Act
+    const output = await sut.create(user)
+    const [statement, parameters] = querySpy.mock.calls[0]
+
+    // Assert
+    expect(output).toBeUndefined()
+    expect(querySpy).toHaveBeenCalledOnce()
+    expect(statement).toContain(
+      'INSERT INTO users (id, first_name, last_name, email, password_hash, created_at, updated_at)'
+    )
+    expect(statement).toContain('VALUES ($1, $2, $3, $4, $5, $6, $7)')
+    expect(parameters).toEqual([
+      IDENTIFIER,
+      'Tifa',
+      'Lockhart',
+      'Tifa.Lockhart@Gmail.com',
+      '$argon2id$v=19$m=19456,t=2,p=1$c2FsdA$aGFzaA',
+      CREATED_AT.toISO(),
+      CREATED_AT.toISO()
+    ])
+  })
+
+  test('Keep the email spelling out of the statement text', async () => {
+    // Arrange
+    const { sut, querySpy, user } = await makeSUT()
+
+    // Act
+    await sut.create(user)
+    const [statement] = querySpy.mock.calls[0]
+
+    // Assert
+    expect(statement).not.toContain(user.email)
+    expect(statement).not.toContain(user.id)
+    expect(statement).not.toContain(user.passwordHash)
+  })
+
+  test('Translate a unique violation on the email index into a conflict problem', async () => {
+    // Arrange
+    const { sut, querySpy, user } = await makeSUT()
+    const databaseError = makeDatabaseError('23505', 'users_email_unique_idx')
+
+    querySpy.mockRejectedValue(databaseError)
+
+    // Act
+    const output = await sut.create(user).catch((error: unknown) => error)
+
+    // Assert
+    expect(output).toBeInstanceOf(Problem)
+    expect((output as Problem).status).toBe(StatusCode.Conflict)
+    expect((output as Problem).serialize()).toEqual({
+      title: 'Email already in use',
+      detail: 'An account with the given email address already exists',
+      instance: undefined
+    })
+  })
+
+  test('Rethrow a unique violation raised by another constraint', async () => {
+    // Arrange
+    const { sut, querySpy, user } = await makeSUT()
+    const databaseError = makeDatabaseError('23505', 'users_pkey')
+
+    querySpy.mockRejectedValue(databaseError)
+
+    // Act
+    const output = await sut.create(user).catch((error: unknown) => error)
+
+    // Assert
+    expect(output).toBe(databaseError)
+    expect(output).not.toBeInstanceOf(Problem)
+  })
+
+  test('Rethrow any other database failure untouched', async () => {
+    // Arrange
+    const { sut, querySpy, user } = await makeSUT()
+    const databaseError = makeDatabaseError('42P01', 'users_email_unique_idx')
+
+    querySpy.mockRejectedValue(databaseError)
+
+    // Act
+    const output = await sut.create(user).catch((error: unknown) => error)
+
+    // Assert
+    expect(output).toBe(databaseError)
+    expect(output).not.toBeInstanceOf(Problem)
+  })
+
+  test('Rethrow a failure that is not a database error', async () => {
+    // Arrange
+    const { sut, querySpy, user } = await makeSUT()
+    const failure = new Error('Connection terminated unexpectedly')
+
+    querySpy.mockRejectedValue(failure)
+
+    // Act
+    const output = await sut.create(user).catch((error: unknown) => error)
+
+    // Assert
+    expect(output).toBe(failure)
+    expect(output).not.toBeInstanceOf(Problem)
+  })
+})


### PR DESCRIPTION
Fecha BAC-30.

Persiste o usuário e detecta e-mail duplicado deixando o `INSERT` falhar, traduzindo o `23505` do PostgreSQL em `Problem` de `409` dentro do repositório (DEC-02). É atômico, custa uma única ida ao banco e é o caso exato em que `code-standards.md` permite `try-catch` na camada `infra`. Consultar antes de inserir abriria janela de corrida e adicionaria um round-trip.

## O que muda

- `src/infra/database/repositories/postgres-users-repository.ts` — `PostgresUsersRepository`, recebendo a `DatabaseConnection` por injeção

## A discriminação do erro

```ts
error instanceof DatabaseError &&
error.code === '23505' &&
error.constraint === 'users_email_unique_idx'
```

`DatabaseError` é export real do `pg` (re-exportado do `pg-protocol` e declarado em `@types/pg`), então a checagem é type-safe sem duck typing. Verificar **também** a constraint importa: sem isso, uma violação futura de outro índice único viraria "e-mail já em uso", que é uma mensagem errada e confusa.

Os timestamps vão como `user.createdAt.toISO()`, e não como `DateTime` cru — o `prepareValue` do `pg` faria `JSON.stringify` do objeto Luxon e o Postgres rejeitaria o valor. Entram como ISO-8601 em UTC e voltam como Luxon pelo parser do OID 1184 (DEC-15).

## Verificação contra um PostgreSQL real

Container descartável com as migrações do projeto aplicadas, script apagado depois:

| Verificação | Resultado |
| -- | -- |
| Grafia do e-mail preservada | `Tifa.Lockhart@Gmail.com` gravado e lido idêntico |
| `created_at` volta como Luxon em UTC | `isDateTime: true`, `isNativeDate: false`, `zoneName: UTC` |
| E-mail duplicado com outra caixa | `Problem` com `status: 409`, `isPgError: false` |
| Estado após a recusa | 1 linha, `id`/`email`/`hash` inalterados |

Os dois testes negativos são o que dá confiança na discriminação, rodados contra o banco de verdade:

- um `23505` genuíno na constraint `users_pkey` **não** é traduzido e propaga como erro cru do `pg`
- um `23502` (NOT NULL) também propaga intacto

Ou seja, só o índice de e-mail produz `409`; todo o resto cai no handler global como `500`, como deve.

## Pilha

Base: `BAC-29`. Mergear depois dele e antes de `BAC-31`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)