### PR TITLE
feat(application): implementar o controller e o schema de validação de `POST /v1/users`

### DIFF
--- a/src/application/controllers/user/create-user.ts
+++ b/src/application/controllers/user/create-user.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+import { type CreateUser } from '@application/usecases/user/create-user'
+import { type HttpRequest, type HttpResponse } from '@common/http/messages'
+import { StatusCode } from '@common/http/statuses'
+
+const NAME_MIN_LENGTH = 2
+const NAME_MAX_LENGTH = 50
+const EMAIL_MAX_LENGTH = 254
+const PASSWORD_MIN_LENGTH = 8
+const PASSWORD_MAX_LENGTH = 64
+
+const nameSchema = z.string().trim().min(NAME_MIN_LENGTH).max(NAME_MAX_LENGTH)
+
+export const createUserSchema = z.object({
+  email: z.string().trim().pipe(z.email().max(EMAIL_MAX_LENGTH)),
+  first_name: nameSchema,
+  last_name: nameSchema,
+  password: z.string().min(PASSWORD_MIN_LENGTH).max(PASSWORD_MAX_LENGTH)
+})
+
+export class CreateUserController {
+  public constructor(private readonly createUser: CreateUser) {}
+
+  public async handle(request: HttpRequest): Promise<HttpResponse> {
+    const body = createUserSchema.parse(request.body)
+
+    await this.createUser.execute({
+      email: body.email,
+      firstName: body.first_name,
+      lastName: body.last_name,
+      password: body.password
+    })
+
+    return { status: StatusCode.NoContent }
+  }
+}

--- a/src/common/http/messages.ts
+++ b/src/common/http/messages.ts
@@ -1,0 +1,10 @@
+import { type StatusCode } from '@common/http/statuses'
+
+export type HttpRequest = Readonly<{
+  body: unknown
+}>
+
+export type HttpResponse = Readonly<{
+  body?: unknown
+  status: StatusCode
+}>

--- a/src/common/http/statuses.ts
+++ b/src/common/http/statuses.ts
@@ -1,4 +1,5 @@
 export enum StatusCode {
+  NoContent = 204,
   BadRequest = 400,
   Conflict = 409,
   InternalServerError = 500

--- a/tests/unit/application/controllers/user/create-user.spec.ts
+++ b/tests/unit/application/controllers/user/create-user.spec.ts
@@ -1,0 +1,354 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { z, ZodError } from 'zod'
+import { CreateUserController, createUserSchema } from '@application/controllers/user/create-user'
+import { CreateUserUseCase } from '@application/usecases/user/create-user'
+import { Problem } from '@common/http/problem'
+import { StatusCode } from '@common/http/statuses'
+import { FakePasswordHasher } from '../../../../mocks/fake-password-hasher'
+import { InMemoryUsersRepository } from '../../../../mocks/in-memory-users-repository'
+
+const PASS_PHRASE = 'cavalo bateria grampo correto'
+
+function makeSUT() {
+  const passwordHasher = new FakePasswordHasher()
+  const usersRepository = new InMemoryUsersRepository()
+  const createUser = new CreateUserUseCase(usersRepository, passwordHasher)
+  const sut = new CreateUserController(createUser)
+  const executeSpy = vi.spyOn(createUser, 'execute')
+  const body = {
+    email: 'Tifa.Lockhart@Gmail.com',
+    first_name: 'Tifa',
+    last_name: 'Lockhart',
+    password: PASS_PHRASE
+  }
+
+  return { sut, body, createUser, executeSpy, usersRepository }
+}
+
+function makeValidBody(overrides: Record<string, unknown> = {}) {
+  return {
+    email: 'tifa.lockhart@gmail.com',
+    first_name: 'Tifa',
+    last_name: 'Lockhart',
+    password: PASS_PHRASE,
+    ...overrides
+  }
+}
+
+function pointersOf(error: ZodError): string[] {
+  return error.issues.map((issue) => issue.path.join('/'))
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('CreateUserController.handle', () => {
+  test('Answers 204 without a body when every field is valid', async () => {
+    // Arrange
+    const { sut, body, executeSpy, usersRepository } = makeSUT()
+
+    // Act
+    const response = await sut.handle({ body })
+
+    // Assert
+    expect(response).toEqual({ status: StatusCode.NoContent })
+    expect(response.status).toBe(204)
+    expect(response.body).toBeUndefined()
+    expect(executeSpy).toHaveBeenCalledOnce()
+    expect(usersRepository.users).toHaveLength(1)
+  })
+
+  test('Trims the edges of the names and the email before handing them over', async () => {
+    // Arrange
+    const { sut, executeSpy } = makeSUT()
+    const body = makeValidBody({
+      email: '  Tifa.Lockhart@Gmail.com  ',
+      first_name: '  Tifa  ',
+      last_name: '  Lockhart  '
+    })
+
+    // Act
+    const response = await sut.handle({ body })
+
+    // Assert
+    expect(response.status).toBe(StatusCode.NoContent)
+    expect(executeSpy).toHaveBeenCalledWith({
+      email: 'Tifa.Lockhart@Gmail.com',
+      firstName: 'Tifa',
+      lastName: 'Lockhart',
+      password: PASS_PHRASE
+    })
+  })
+
+  test('Hands the password over exactly as it was sent', async () => {
+    // Arrange
+    const { sut, executeSpy } = makeSUT()
+    const paddedPassword = `  ${PASS_PHRASE}  `
+    const body = makeValidBody({ password: paddedPassword })
+
+    // Act
+    await sut.handle({ body })
+    const [input] = executeSpy.mock.calls[0]
+
+    // Assert
+    expect(input.password).toBe(paddedPassword)
+    expect(input.password).not.toBe(PASS_PHRASE)
+  })
+
+  test('Ignores keys that the body does not declare', async () => {
+    // Arrange
+    const { sut, executeSpy } = makeSUT()
+    const body = makeValidBody({ id: '01M063ET5G1JAXFBKESMJKJ9G3', role: 'admin' })
+
+    // Act
+    const response = await sut.handle({ body })
+
+    // Assert
+    expect(response.status).toBe(StatusCode.NoContent)
+    expect(executeSpy).toHaveBeenCalledWith({
+      email: 'tifa.lockhart@gmail.com',
+      firstName: 'Tifa',
+      lastName: 'Lockhart',
+      password: PASS_PHRASE
+    })
+  })
+
+  test('Accepts names written with accent, hyphen and apostrophe', async () => {
+    // Arrange
+    const { sut, executeSpy } = makeSUT()
+    const body = makeValidBody({ first_name: "D'Ávila", last_name: 'Saint-Exupéry' })
+
+    // Act
+    const response = await sut.handle({ body })
+
+    // Assert
+    expect(response.status).toBe(StatusCode.NoContent)
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ firstName: "D'Ávila", lastName: 'Saint-Exupéry' })
+    )
+  })
+
+  test('Refuses an invalid body without reaching the use case', async () => {
+    // Arrange
+    const { sut, executeSpy, usersRepository } = makeSUT()
+    const body = makeValidBody({ email: 'tifa@' })
+
+    // Act
+    const promise = sut.handle({ body })
+
+    // Assert
+    await expect(promise).rejects.toBeInstanceOf(ZodError)
+    expect(executeSpy).not.toHaveBeenCalled()
+    expect(usersRepository.users).toHaveLength(0)
+  })
+})
+
+describe('createUserSchema', () => {
+  test('Gathers the errors of every field into a single failure', () => {
+    // Arrange
+    const body = {
+      email: 'tifa@',
+      first_name: 'T',
+      last_name: '',
+      password: 'short'
+    }
+
+    // Act
+    const result = createUserSchema.safeParse(body)
+    const errors = Problem.fromZod(result.error as ZodError).serialize().errors
+
+    // Assert
+    expect(result.success).toBe(false)
+    expect(pointersOf(result.error as ZodError)).toEqual([
+      'email',
+      'first_name',
+      'last_name',
+      'password'
+    ])
+    expect(errors).toHaveLength(4)
+  })
+
+  test('Points out every required field that is missing', () => {
+    // Act
+    const result = createUserSchema.safeParse({})
+
+    // Assert
+    expect(result.success).toBe(false)
+    expect(pointersOf(result.error as ZodError)).toEqual([
+      'email',
+      'first_name',
+      'last_name',
+      'password'
+    ])
+  })
+
+  test('Trims the edges of the names and of the email before validating', () => {
+    // Arrange
+    const body = makeValidBody({
+      email: '  Tifa.Lockhart@Gmail.com  ',
+      first_name: '  Tifa  ',
+      last_name: '  Lockhart  '
+    })
+
+    // Act
+    const result = createUserSchema.safeParse(body)
+
+    // Assert
+    expect(result.success).toBe(true)
+    expect(result.data?.first_name).toBe('Tifa')
+    expect(result.data?.last_name).toBe('Lockhart')
+    expect(result.data?.email).toBe('Tifa.Lockhart@Gmail.com')
+  })
+
+  test('Trims the email before checking its format, and not after', () => {
+    // Arrange
+    const paddedEmail = '  Tifa.Lockhart@Gmail.com  '
+    const trimAfterFormat = z.email().trim()
+
+    // Act
+    const trimBeforeFormat = createUserSchema.safeParse(makeValidBody({ email: paddedEmail }))
+    const chained = trimAfterFormat.safeParse(paddedEmail)
+
+    // Assert
+    expect(trimBeforeFormat.success).toBe(true)
+    expect(trimBeforeFormat.data?.email).toBe('Tifa.Lockhart@Gmail.com')
+    expect(chained.success).toBe(false)
+  })
+
+  test('Does not trim the password', () => {
+    // Arrange
+    const paddedPassword = `  ${PASS_PHRASE}  `
+
+    // Act
+    const result = createUserSchema.safeParse(makeValidBody({ password: paddedPassword }))
+
+    // Assert
+    expect(result.success).toBe(true)
+    expect(result.data?.password).toBe(paddedPassword)
+  })
+
+  test('Keeps the email spelling untouched', () => {
+    // Arrange
+    const email = 'Tifa.Lockhart+fincheck@Gmail.com'
+
+    // Act
+    const result = createUserSchema.safeParse(makeValidBody({ email }))
+
+    // Assert
+    expect(result.success).toBe(true)
+    expect(result.data?.email).toBe(email)
+  })
+
+  test('Accepts names on both ends of the allowed length', () => {
+    // Arrange
+    const shortest = 'Ti'
+    const longest = 'T'.repeat(50)
+
+    // Act
+    const result = createUserSchema.safeParse(
+      makeValidBody({ first_name: shortest, last_name: longest })
+    )
+
+    // Assert
+    expect(result.success).toBe(true)
+    expect(result.data?.first_name).toBe(shortest)
+    expect(result.data?.last_name).toBe(longest)
+  })
+
+  test('Refuses names outside the allowed length', () => {
+    // Arrange
+    const tooShort = makeValidBody({ first_name: 'T', last_name: 'L' })
+    const tooLong = makeValidBody({ first_name: 'T'.repeat(51), last_name: 'L'.repeat(51) })
+
+    // Act
+    const shortResult = createUserSchema.safeParse(tooShort)
+    const longResult = createUserSchema.safeParse(tooLong)
+
+    // Assert
+    expect(pointersOf(shortResult.error as ZodError)).toEqual(['first_name', 'last_name'])
+    expect(shortResult.error?.issues[0].code).toBe('too_small')
+    expect(pointersOf(longResult.error as ZodError)).toEqual(['first_name', 'last_name'])
+    expect(longResult.error?.issues[0].code).toBe('too_big')
+  })
+
+  test('Refuses a name that is only spaces', () => {
+    // Act
+    const result = createUserSchema.safeParse(makeValidBody({ first_name: '   ' }))
+
+    // Assert
+    expect(pointersOf(result.error as ZodError)).toEqual(['first_name'])
+  })
+
+  test('Refuses an email without address format', () => {
+    // Arrange
+    const withoutDomain = makeValidBody({ email: 'tifa@' })
+    const withoutAt = makeValidBody({ email: 'tifa.gmail.com' })
+
+    // Act
+    const withoutDomainResult = createUserSchema.safeParse(withoutDomain)
+    const withoutAtResult = createUserSchema.safeParse(withoutAt)
+
+    // Assert
+    expect(pointersOf(withoutDomainResult.error as ZodError)).toEqual(['email'])
+    expect(pointersOf(withoutAtResult.error as ZodError)).toEqual(['email'])
+  })
+
+  test('Refuses an email longer than the allowed length', () => {
+    // Arrange
+    const domain = '@gmail.com'
+    const longest = `${'t'.repeat(254 - domain.length)}${domain}`
+    const tooLong = `${'t'.repeat(255 - domain.length)}${domain}`
+
+    // Act
+    const longestResult = createUserSchema.safeParse(makeValidBody({ email: longest }))
+    const tooLongResult = createUserSchema.safeParse(makeValidBody({ email: tooLong }))
+
+    // Assert
+    expect(longestResult.success).toBe(true)
+    expect(pointersOf(tooLongResult.error as ZodError)).toEqual(['email'])
+    expect(tooLongResult.error?.issues[0].code).toBe('too_big')
+  })
+
+  test('Accepts passwords on both ends of the allowed length', () => {
+    // Arrange
+    const shortest = 'a'.repeat(8)
+    const longest = 'a'.repeat(64)
+
+    // Act
+    const shortestResult = createUserSchema.safeParse(makeValidBody({ password: shortest }))
+    const longestResult = createUserSchema.safeParse(makeValidBody({ password: longest }))
+
+    // Assert
+    expect(shortestResult.data?.password).toBe(shortest)
+    expect(longestResult.data?.password).toBe(longest)
+  })
+
+  test('Refuses passwords outside the allowed length', () => {
+    // Arrange
+    const tooShort = makeValidBody({ password: 'a'.repeat(7) })
+    const tooLong = makeValidBody({ password: 'a'.repeat(65) })
+
+    // Act
+    const shortResult = createUserSchema.safeParse(tooShort)
+    const longResult = createUserSchema.safeParse(tooLong)
+
+    // Assert
+    expect(pointersOf(shortResult.error as ZodError)).toEqual(['password'])
+    expect(shortResult.error?.issues[0].code).toBe('too_small')
+    expect(pointersOf(longResult.error as ZodError)).toEqual(['password'])
+    expect(longResult.error?.issues[0].code).toBe('too_big')
+  })
+
+  test('Accepts a password without uppercase, digit or symbol', () => {
+    // Arrange
+    const password = 'cavalobateria'
+
+    // Act
+    const result = createUserSchema.safeParse(makeValidBody({ password }))
+
+    // Assert
+    expect(result.success).toBe(true)
+    expect(result.data?.password).toBe(password)
+  })
+})


### PR DESCRIPTION
Fecha BAC-31.

A borda da requisição: valida os quatro campos de uma vez, chama o caso de uso e responde `204` sem corpo.

## O que muda

- `src/application/controllers/user/create-user.ts` — `createUserSchema` e `CreateUserController`
- `src/common/http/messages.ts` — `HttpRequest` / `HttpResponse` **(adição fora do texto da issue, ver abaixo)**
- `src/common/http/statuses.ts` — `NoContent = 204`

## Schema

```ts
email:      z.string().trim().pipe(z.email().max(254))
first_name: z.string().trim().min(2).max(50)   // idem last_name
password:   z.string().min(8).max(64)
```

`z.object` descarta chaves desconhecidas por padrão, então chaves não previstas são ignoradas. Nada encadeia entre campos, então os quatro erros acumulam numa única resposta (CA-11).

**DEC-10 verificada empiricamente** contra o zod 4.4.3 antes de escrever o código: `z.string().trim().pipe(z.email())` aceita `"  Tifa.Lockhart@Gmail.com  "` e devolve sem os espaços, enquanto `z.email().trim()` rejeita com `invalid_format`. Esse contraste virou teste de regressão, então a ordem não pode ser invertida por engano depois.

## Duas decisões de julgamento

**Nomes não têm regex de classe de caracteres.** CA-09 exige que acento, hífen e apóstrofo sejam *aceitos*, e nem o PRD nem a TechSpec restringem o alfabeto. Um regex só adicionaria uma regra de rejeição que ninguém pediu, com risco de recusar nomes legítimos. `trim` + limites de tamanho satisfazem CA-06 a CA-09 como estão escritos.

**O `ZodError` sobe para o handler global** em vez de ser convertido no controller. A tradução `ZodError → Problem` já existe em `Problem.fromZod` e passa a viver num lugar só, em vez de ser repetida em cada controller. Também dispensa `try-catch`, que é proibido fora da `infra`. O teste assere as duas metades: o controller rejeita com `ZodError`, e `Problem.fromZod` sobre esse erro serializa quatro entradas em `errors`.

## Adição fora do texto da issue

`HttpRequest`/`HttpResponse` e `StatusCode.NoContent` não estão na TechSpec, que não nomeia um contrato controller↔router. Sem eles, o controller precisaria importar tipos do Fastify, e a camada `application` passaria a depender de `main` — violação direta de `folder-standards.md`. São dois tipos mínimos:

```ts
type HttpRequest = Readonly<{ body: unknown }>
type HttpResponse = Readonly<{ body?: unknown; status: StatusCode }>
```

O router da BAC-32 vai adaptar o Fastify para eles.

## Testes

20 testes novos. TU-06 (quatro campos inválidos → quatro `pointer`, um por campo), TU-07 (nome e e-mail desbastados antes de validar, caixa e sub-endereçamento `+` preservados) e TU-08 (senha com espaços chega ao caso de uso byte a byte idêntica), mais: `204` sem corpo e sem dado de sessão, campos ausentes, limites de nome 2/50 e 1/51, nome só com espaços, nomes acentuados/com hífen/com apóstrofo, e-mails `tifa@` e `tifa.gmail.com`, e-mail de 254 e 255, senha de 8/64 e 7/65, e senha sem maiúscula, número ou símbolo.

## Pilha

Base: `BAC-30`. É o topo da onda 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)