### PR TITLE
feat(main): compor a rota `POST /v1/users` e o ciclo de vida da api

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -1,12 +1,23 @@
 import { fastify, type FastifyInstance } from 'fastify'
+import { CreateUserController } from '@application/controllers/user/create-user'
+import { CreateUserUseCase } from '@application/usecases/user/create-user'
 import { type Configuration } from '@common/core/config'
+import { DatabaseConnection } from '@infra/database/connection'
+import { PostgresUsersRepository } from '@infra/database/repositories/postgres-users-repository'
+import { Argon2PasswordHasher } from '@infra/security/argon2-password-hasher'
 import { problem } from '@main/plugins/problem'
+import { router } from '@main/router'
 
 export class FincheckAPI {
   private constructor(
     private readonly app: FastifyInstance,
-    private readonly config: Configuration
+    private readonly config: Configuration,
+    private readonly connection: DatabaseConnection
   ) {}
+
+  public get address(): string {
+    return this.app.listeningOrigin
+  }
 
   public async start(): Promise<void> {
     await this.app.listen({
@@ -17,13 +28,20 @@ export class FincheckAPI {
 
   public async stop(): Promise<void> {
     await this.app.close()
+    await this.connection.disconnect()
   }
 
   public static async create(config: Configuration): Promise<FincheckAPI> {
     const app = fastify()
+    const connection = DatabaseConnection.create(config)
+    const usersRepository = new PostgresUsersRepository(connection)
+    const passwordHasher = new Argon2PasswordHasher()
+    const createUser = new CreateUserUseCase(usersRepository, passwordHasher)
 
     app.setErrorHandler(problem)
 
-    return new FincheckAPI(app, config)
+    await app.register(router({ createUser: new CreateUserController(createUser) }))
+
+    return new FincheckAPI(app, config, connection)
   }
 }

--- a/src/main/router.ts
+++ b/src/main/router.ts
@@ -1,0 +1,25 @@
+import { type FastifyInstance, type FastifyReply, type FastifyRequest } from 'fastify'
+import { type CreateUserController } from '@application/controllers/user/create-user'
+import { type HttpRequest, type HttpResponse } from '@common/http/messages'
+
+interface Controller {
+  handle(request: HttpRequest): Promise<HttpResponse>
+}
+
+export type Controllers = Readonly<{
+  createUser: CreateUserController
+}>
+
+function adapt(controller: Controller) {
+  return async (request: FastifyRequest, reply: FastifyReply): Promise<FastifyReply> => {
+    const response = await controller.handle({ body: request.body })
+
+    return reply.code(response.status).send(response.body)
+  }
+}
+
+export function router(controllers: Controllers) {
+  return async (app: FastifyInstance): Promise<void> => {
+    app.post('/v1/users', adapt(controllers.createUser))
+  }
+}

--- a/tests/unit/main/app.spec.ts
+++ b/tests/unit/main/app.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { Configuration } from '@common/core/config'
+import { StatusCode } from '@common/http/statuses'
+import { DatabaseConnection } from '@infra/database/connection'
+import { FincheckAPI } from '@main/app'
+
+async function makeSUT() {
+  const config = await Configuration.from({
+    APP_ENV: 'test',
+    APP_HOST: '127.0.0.1',
+    APP_PORT: '0',
+    DATABASE_URL: 'postgres://postgres:postgres@127.0.0.1:5435/fincheck'
+  })
+  const disconnect = vi.spyOn(DatabaseConnection.prototype, 'disconnect').mockResolvedValue()
+  const sut = await FincheckAPI.create(config)
+
+  return { sut, disconnect }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('FincheckAPI', () => {
+  test('Expose the address the server bound to instead of the configured port', async () => {
+    // Arrange
+    const { sut } = await makeSUT()
+
+    // Act
+    await sut.start()
+    const address = sut.address
+
+    // Assert
+    expect(address).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/)
+    expect(address).not.toContain(':0')
+
+    await sut.stop()
+  })
+
+  test('Serve the create user route', async () => {
+    // Arrange
+    const { sut } = await makeSUT()
+
+    // Act
+    await sut.start()
+    const response = await fetch(`${sut.address}/v1/users`, {
+      body: JSON.stringify({}),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST'
+    })
+    const body = await response.json()
+
+    // Assert
+    expect(response.status).toEqual(StatusCode.BadRequest)
+    expect(body).toMatchObject({ title: 'Request validation failed', instance: '/v1/users' })
+
+    await sut.stop()
+  })
+
+  test('Disconnect from the database when stopped', async () => {
+    // Arrange
+    const { sut, disconnect } = await makeSUT()
+
+    await sut.start()
+
+    // Act
+    await sut.stop()
+
+    // Assert
+    expect(disconnect).toHaveBeenCalledOnce()
+  })
+
+  test('Refuse connections once stopped', async () => {
+    // Arrange
+    const { sut } = await makeSUT()
+
+    await sut.start()
+    const address = sut.address
+
+    // Act
+    await sut.stop()
+
+    // Assert
+    await expect(fetch(`${address}/v1/users`, { method: 'POST' })).rejects.toThrow()
+  })
+})

--- a/tests/unit/main/router.spec.ts
+++ b/tests/unit/main/router.spec.ts
@@ -1,0 +1,73 @@
+import { fastify } from 'fastify'
+import { describe, expect, test, vi } from 'vitest'
+import { type CreateUserController } from '@application/controllers/user/create-user'
+import { type HttpRequest, type HttpResponse } from '@common/http/messages'
+import { StatusCode } from '@common/http/statuses'
+import { router } from '@main/router'
+
+function makeSUT(response: HttpResponse = { status: StatusCode.NoContent }) {
+  const handle = vi.fn(async (_request: HttpRequest): Promise<HttpResponse> => response)
+  const createUser = { handle } as unknown as CreateUserController
+  const sut = fastify()
+
+  sut.register(router({ createUser }))
+
+  return { sut, createUser: handle }
+}
+
+describe('router', () => {
+  test('Declare the create user route under the version one prefix', async () => {
+    // Arrange
+    const { sut } = makeSUT()
+
+    // Act
+    const response = await sut.inject({ method: 'POST', url: '/users', payload: {} })
+
+    // Assert
+    expect(response.statusCode).toEqual(404)
+  })
+
+  test('Hand the request body to the create user controller', async () => {
+    // Arrange
+    const { sut, createUser } = makeSUT()
+    const payload = {
+      email: 'tifa.lockhart@gmail.com',
+      first_name: 'Tifa',
+      last_name: 'Lockhart',
+      password: 'm1dg4r 1s 4ws0m3'
+    }
+
+    // Act
+    await sut.inject({ method: 'POST', url: '/v1/users', payload })
+
+    // Assert
+    expect(createUser).toHaveBeenCalledOnce()
+    expect(createUser).toHaveBeenCalledWith({ body: payload })
+  })
+
+  test('Answer the created account without a body', async () => {
+    // Arrange
+    const { sut } = makeSUT()
+
+    // Act
+    const response = await sut.inject({ method: 'POST', url: '/v1/users', payload: {} })
+
+    // Assert
+    expect(response.statusCode).toEqual(StatusCode.NoContent)
+    expect(response.body).toEqual('')
+    expect(response.headers['content-type']).toBeUndefined()
+  })
+
+  test('Answer with the status and the body returned by the controller', async () => {
+    // Arrange
+    const body = { user: { id: '01M063ET5G1JAXFBKESMJKJ9G3' } }
+    const { sut } = makeSUT({ body, status: StatusCode.Conflict })
+
+    // Act
+    const response = await sut.inject({ method: 'POST', url: '/v1/users', payload: {} })
+
+    // Assert
+    expect(response.statusCode).toEqual(StatusCode.Conflict)
+    expect(response.json()).toEqual(body)
+  })
+})


### PR DESCRIPTION
Fecha BAC-32.

A montagem final: as peças isoladas viram um endpoint público de verdade.

## O que muda

- `src/main/router.ts` — declara `POST /v1/users` e adapta Fastify → `HttpRequest` e `HttpResponse` → reply. Exportado como fábrica de plugin `router(controllers)`, para que a camada `application` siga agnóstica de framework
- `src/main/app.ts` — `create()` monta a cadeia `DatabaseConnection` → `PostgresUsersRepository` + `Argon2PasswordHasher` → `CreateUserUseCase` → `CreateUserController` e registra o router; ganha o getter `address`; `stop()` fecha o servidor e depois encerra o pool

`src/main/main.ts` não precisou mudar.

## O endereço que a BAC-33 vai consumir

`FincheckAPI.address` devolve o `listeningOrigin` do Fastify, derivado de `server.addresses()` **depois** do `listen`. Isso importa porque `.env.test` usa `APP_PORT=0` e quem escolhe a porta é o SO — ler da configuração devolveria `0`. Verificado: configurado `0`, reportado `50175`.

É uma origem completa, então o orquestrador usa direto como `fetch(\`${app.address}/v1/users\`)`, igual ao exemplo de `testing-standards.md`. **Cuidado**: lança se lido antes de `start()`.

## Verificação manual de ponta a ponta

Servidor real contra Postgres real:

| # | Cenário | Resultado |
| -- | -- | -- |
| 1 | Cadastro válido | `204`, sem `content-type`, sem `set-cookie`, sem token |
| 2 | Mesmo e-mail em maiúsculas | `409 Email already in use` |
| 3 | Quatro campos inválidos | `400` com os quatro `pointer` numa resposta só |
| 4 | JSON malformado | `400 Malformed request body` |
| 5 | `stop()` | handles abertos após parar: `[]`, processo encerra com código `0` |

A linha persistida confirma o que mais importava: `email` gravado como `Tifa.Lockhart@Gmail.com`, com a grafia original, e `password_hash` com prefixo `$argon2id$v=19$m=19456,t=2,p=1` — os parâmetros da OWASP chegando intactos até o banco. `created_at` igual a `updated_at`, em UTC.

## Nota sobre a suíte unitária

`tests/unit/main/app.spec.ts` abre um socket real na porta `0` e mocka `DatabaseConnection.prototype.disconnect`, então não precisa de banco: exercita o caminho de validação `400`, que curto-circuita antes de qualquer query.

## Pilha

Base: `BAC-31`. Mergear depois dele e antes de `BAC-33`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)