### PR TITLE
feat(code): domínio de cadastro — Email, User, UserActivationToken e UserRepository

### DIFF
--- a/.specs/cadastro-de-usuarios/tasks.md
+++ b/.specs/cadastro-de-usuarios/tasks.md
@@ -9,7 +9,7 @@ A implementação é dividida em 6 ondas e 13 tarefas. A onda 1 estabelece a fun
 | TASK-1  | Fundação do projeto: dependências, apelidos de módulo e configuração de ambiente | ✅ Concluído    |                                        |
 | TASK-2  | Conexão com o PostgreSQL e migrações do esquema                                  | 🔄 Em Progresso | TASK-1                                 |
 | TASK-3  | Núcleo HTTP: contrato de controller, `204 No Content` e adaptador do Fastify     | ✏️ Não Iniciado | TASK-1                                 |
-| TASK-4  | Domínio: `Email`, `User`, `UserActivationToken` e o contrato `UserRepository`    | 🔄 Em Progresso | TASK-1                                 |
+| TASK-4  | Domínio: `Email`, `User`, `UserActivationToken` e o contrato `UserRepository`    | ✅ Concluído    | TASK-1                                 |
 | TASK-5  | Repositório de usuários em SQL                                                   | ✏️ Não Iniciado | TASK-2, TASK-4                         |
 | TASK-6  | Derivação de hash de senha com Argon2id                                          | ✏️ Não Iniciado | TASK-1                                 |
 | TASK-7  | Template do e-mail de ativação e gateway SMTP                                    | ✏️ Não Iniciado | TASK-1                                 |

--- a/.specs/cadastro-de-usuarios/tasks/task-4.md
+++ b/.specs/cadastro-de-usuarios/tasks/task-4.md
@@ -4,13 +4,13 @@ A normalização do endereço de e-mail, a geração do identificador e dos meta
 
 ## Subtarefas
 
-- [ ] Criar `src/domain/value-objects/email.ts` com a classe `Email` e a fábrica `Email.create`, que converte todo o endereço para minúsculas e, quando o nome do usuário contém `+` em posição diferente da primeira, descarta tudo do `+` até o `@`, preservando pontos
-- [ ] Criar `src/domain/entities/user.ts` com a entidade `User` e a fábrica `User.create`, que gera o `id` em ULID com `ulidx`, define `createdAt` e `updatedAt` em UTC e nasce com `verifiedAt` nulo
-- [ ] Ordenar as propriedades de `User` conforme o padrão de código (identificador, propriedades em ordem alfabética, metadados) e marcar como `readonly` as que nunca são atualizadas
-- [ ] Criar `src/domain/entities/user-activation-token.ts` com `UserActivationToken.create(userId)`, que gera o `id` em ULID, o valor com 16 bytes de `crypto.randomBytes` serializados em hexadecimal minúsculo e o `expiresAt` 15 minutos após a criação, com a validade extraída em constante
-- [ ] Implementar `UserActivationToken.restore(properties)` para reconstruir a entidade a partir da linha do banco e `isUsable()`, que devolve verdadeiro apenas quando `usedAt` é nulo e `expiresAt` ainda não passou
-- [ ] Criar `src/domain/repositories/user.ts` com o tipo `CreateUserInput` e a interface `UserRepository`, declarando `create`, `findActivationToken` e `activateUser` com as assinaturas da TechSpec
-- [ ] Executar `npm run format:check` e `npm run lint:check` e corrigir o que apontarem
+- [x] Criar `src/domain/value-objects/email.ts` com a classe `Email` e a fábrica `Email.create`, que converte todo o endereço para minúsculas e, quando o nome do usuário contém `+` em posição diferente da primeira, descarta tudo do `+` até o `@`, preservando pontos
+- [x] Criar `src/domain/entities/user.ts` com a entidade `User` e a fábrica `User.create`, que gera o `id` em ULID com `ulidx`, define `createdAt` e `updatedAt` em UTC e nasce com `verifiedAt` nulo
+- [x] Ordenar as propriedades de `User` conforme o padrão de código (identificador, propriedades em ordem alfabética, metadados) e marcar como `readonly` as que nunca são atualizadas
+- [x] Criar `src/domain/entities/user-activation-token.ts` com `UserActivationToken.create(userId)`, que gera o `id` em ULID, o valor com 16 bytes de `crypto.randomBytes` serializados em hexadecimal minúsculo e o `expiresAt` 15 minutos após a criação, com a validade extraída em constante
+- [x] Implementar `UserActivationToken.restore(properties)` para reconstruir a entidade a partir da linha do banco e `isUsable()`, que devolve verdadeiro apenas quando `usedAt` é nulo e `expiresAt` ainda não passou
+- [x] Criar `src/domain/repositories/user.ts` com o tipo `CreateUserInput` e a interface `UserRepository`, declarando `create`, `findActivationToken` e `activateUser` com as assinaturas da TechSpec
+- [x] Executar `npm run format:check` e `npm run lint:check` e corrigir o que apontarem
 
 ## Critérios de Aceitação
 

--- a/src/domain/entities/user-activation-token.ts
+++ b/src/domain/entities/user-activation-token.ts
@@ -1,0 +1,53 @@
+import { randomBytes } from 'node:crypto'
+import { ulid } from 'ulidx'
+
+const ACTIVATION_TOKEN_TTL_MS = 15 * 60 * 1000
+const ACTIVATION_TOKEN_BYTES = 16
+
+type RestoreTokenProperties = Readonly<{
+  createdAt: Date
+  expiresAt: Date
+  id: string
+  usedAt: Date | null
+  userId: string
+  value: string
+}>
+
+export class UserActivationToken {
+  public readonly id: string
+  public readonly userId: string
+  public readonly expiresAt: Date
+  public usedAt: Date | null
+  public readonly value: string
+  public readonly createdAt: Date
+
+  private constructor(properties: RestoreTokenProperties) {
+    this.id = properties.id
+    this.userId = properties.userId
+    this.expiresAt = properties.expiresAt
+    this.usedAt = properties.usedAt
+    this.value = properties.value
+    this.createdAt = properties.createdAt
+  }
+
+  public static create(userId: string): UserActivationToken {
+    const createdAt = new Date()
+
+    return new UserActivationToken({
+      id: ulid(),
+      userId,
+      expiresAt: new Date(createdAt.getTime() + ACTIVATION_TOKEN_TTL_MS),
+      usedAt: null,
+      value: randomBytes(ACTIVATION_TOKEN_BYTES).toString('hex'),
+      createdAt
+    })
+  }
+
+  public static restore(properties: RestoreTokenProperties): UserActivationToken {
+    return new UserActivationToken(properties)
+  }
+
+  public isUsable(): boolean {
+    return this.usedAt === null && this.expiresAt > new Date()
+  }
+}

--- a/src/domain/entities/user.ts
+++ b/src/domain/entities/user.ts
@@ -1,0 +1,55 @@
+import { type Email } from '@domain/value-objects/email'
+import { ulid } from 'ulidx'
+
+type CreateUserProperties = Readonly<{
+  email: Email
+  firstName: string
+  lastName: string
+  passwordHash: string
+}>
+
+export class User {
+  public readonly id: string
+  public readonly email: string
+  public readonly firstName: string
+  public readonly lastName: string
+  public readonly passwordHash: string
+  public verifiedAt: Date | null
+  public readonly createdAt: Date
+  public updatedAt: Date
+
+  private constructor(properties: {
+    id: string
+    email: string
+    firstName: string
+    lastName: string
+    passwordHash: string
+    verifiedAt: Date | null
+    createdAt: Date
+    updatedAt: Date
+  }) {
+    this.id = properties.id
+    this.email = properties.email
+    this.firstName = properties.firstName
+    this.lastName = properties.lastName
+    this.passwordHash = properties.passwordHash
+    this.verifiedAt = properties.verifiedAt
+    this.createdAt = properties.createdAt
+    this.updatedAt = properties.updatedAt
+  }
+
+  public static create(properties: CreateUserProperties): User {
+    const now = new Date()
+
+    return new User({
+      id: ulid(),
+      email: properties.email.value,
+      firstName: properties.firstName,
+      lastName: properties.lastName,
+      passwordHash: properties.passwordHash,
+      verifiedAt: null,
+      createdAt: now,
+      updatedAt: now
+    })
+  }
+}

--- a/src/domain/repositories/user.ts
+++ b/src/domain/repositories/user.ts
@@ -1,0 +1,13 @@
+import { type User } from '@domain/entities/user'
+import { type UserActivationToken } from '@domain/entities/user-activation-token'
+
+export type CreateUserInput = Readonly<{
+  token: UserActivationToken
+  user: User
+}>
+
+export interface UserRepository {
+  activateUser(token: UserActivationToken): Promise<boolean>
+  create(input: CreateUserInput): Promise<boolean>
+  findActivationToken(value: string): Promise<UserActivationToken | null>
+}

--- a/src/domain/value-objects/email.ts
+++ b/src/domain/value-objects/email.ts
@@ -1,0 +1,24 @@
+const ALIAS_SEPARATOR = '+'
+const DOMAIN_SEPARATOR = '@'
+
+export class Email {
+  public readonly value: string
+
+  private constructor(value: string) {
+    this.value = value
+  }
+
+  public static create(value: string): Email {
+    const lowercased = value.toLowerCase()
+    const [localPart, domain] = lowercased.split(DOMAIN_SEPARATOR)
+    const aliasIndex = localPart.indexOf(ALIAS_SEPARATOR)
+
+    if (aliasIndex <= 0) {
+      return new Email(lowercased)
+    }
+
+    const normalizedLocalPart = localPart.slice(0, aliasIndex)
+
+    return new Email(`${normalizedLocalPart}${DOMAIN_SEPARATOR}${domain}`)
+  }
+}


### PR DESCRIPTION
## Resumo

Implementa a TASK-4 do épico `cadastro-de-usuarios`: a camada de domínio usada pelo cadastro e ativação de contas.

- `src/domain/value-objects/email.ts`: objeto de valor `Email` com `Email.create`, normalizando o endereço para minúsculas e removendo apelidos (tudo entre o primeiro `+` que não esteja na primeira posição e o `@`), preservando pontos.
- `src/domain/entities/user.ts`: entidade `User` com fábrica `User.create`, gerando `id` via ULID (`ulidx`), `createdAt`/`updatedAt` em UTC no mesmo instante e `verifiedAt` nulo na criação.
- `src/domain/entities/user-activation-token.ts`: entidade `UserActivationToken` com `create` (token de 16 bytes de `crypto.randomBytes` em hexadecimal, `expiresAt` 15 minutos após a criação via a constante `ACTIVATION_TOKEN_TTL_MS`), `restore` (reconstrução a partir do banco) e `isUsable()` (token não usado e ainda não expirado).
- `src/domain/repositories/user.ts`: tipo `CreateUserInput` e interface `UserRepository` (`create`, `findActivationToken`, `activateUser`), conforme os contratos da TechSpec.

Este PR é empilhado sobre `feature/signup-task-1` (Stacked PR).

Referências: TASK-4 (`.specs/cadastro-de-usuarios/tasks/task-4.md`), critérios de aceitação CA-1, CA-15, CA-16, CA-20, CA-21, CA-24, CA-25 e CA-27.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint:check`
- [x] `npx tsc --noEmit` (único erro remanescente é pré-existente e fora de escopo, em `src/main/plugins/problem.ts(6,7)`)
- Sem testes automatizados nesta tarefa: o comportamento será exercitado pelas suítes de TASK-12/TASK-13.