### PR TITLE
feat(code): conexão com postgresql e migrações do esquema de usuários

### DIFF
--- a/.specs/cadastro-de-usuarios/tasks.md
+++ b/.specs/cadastro-de-usuarios/tasks.md
@@ -7,7 +7,7 @@ A implementação é dividida em 6 ondas e 13 tarefas. A onda 1 estabelece a fun
 | #       | Título                                                                           | Status          | Bloqueado Por                          |
 | :------ | :------------------------------------------------------------------------------- | :-------------- | -------------------------------------- |
 | TASK-1  | Fundação do projeto: dependências, apelidos de módulo e configuração de ambiente | ✅ Concluído    |                                        |
-| TASK-2  | Conexão com o PostgreSQL e migrações do esquema                                  | 🔄 Em Progresso | TASK-1                                 |
+| TASK-2  | Conexão com o PostgreSQL e migrações do esquema                                  | ✅ Concluído    | TASK-1                                 |
 | TASK-3  | Núcleo HTTP: contrato de controller, `204 No Content` e adaptador do Fastify     | ✏️ Não Iniciado | TASK-1                                 |
 | TASK-4  | Domínio: `Email`, `User`, `UserActivationToken` e o contrato `UserRepository`    | 🔄 Em Progresso | TASK-1                                 |
 | TASK-5  | Repositório de usuários em SQL                                                   | ✏️ Não Iniciado | TASK-2, TASK-4                         |

--- a/.specs/cadastro-de-usuarios/tasks/task-2.md
+++ b/.specs/cadastro-de-usuarios/tasks/task-2.md
@@ -4,14 +4,14 @@ O produto ainda não tem persistência nem versionamento de esquema. Esta tarefa
 
 ## Subtarefas
 
-- [ ] Criar `src/infra/database/connection.ts` com o tipo `PostgresConfig` e a classe `Database`, expondo `connect`, `query`, `transaction` e `disconnect` sobre o `Pool` do `pg`
-- [ ] Implementar `transaction` retirando um cliente do pool, emitindo `BEGIN`, executando o handler, emitindo `COMMIT` quando ele resolve e `ROLLBACK` quando ele lança, e sempre devolvendo o cliente ao pool — único `try-catch` da tarefa, permitido por ser camada `infra`
-- [ ] Gerar a migração da tabela `users` com `npm run migration:create`, deixando o prefixo de timestamp para a ferramenta
-- [ ] Escrever o `up` e o `down` da migração de `users` com as colunas `id`, `first_name`, `last_name`, `email`, `password_hash`, `verified_at`, `created_at` e `updated_at`, a chave primária `users_pkey` e a restrição `users_email_unique`
-- [ ] Gerar a migração da tabela `user_activation_tokens` com `npm run migration:create`
-- [ ] Escrever o `up` e o `down` dessa migração com as colunas `id`, `user_id_fk`, `token`, `expires_at`, `used_at` e `created_at`, a chave primária `user_activation_tokens_pkey`, a restrição `user_activation_tokens_token_unique`, o índice `user_activation_tokens_user_id_fk_idx` e a chave estrangeira `user_activation_tokens_user_id_fk_fkey` para `users(id)` com `ON DELETE CASCADE`
-- [ ] Subir o compose local, aplicar as migrações com `npm run migration:up` e conferir tabelas, colunas e índices criados; validar o `down` revertendo e reaplicando
-- [ ] Executar `npm run format:check` e `npm run lint:check` e corrigir o que apontarem
+- [x] Criar `src/infra/database/connection.ts` com o tipo `PostgresConfig` e a classe `Database`, expondo `connect`, `query`, `transaction` e `disconnect` sobre o `Pool` do `pg`
+- [x] Implementar `transaction` retirando um cliente do pool, emitindo `BEGIN`, executando o handler, emitindo `COMMIT` quando ele resolve e `ROLLBACK` quando ele lança, e sempre devolvendo o cliente ao pool — único `try-catch` da tarefa, permitido por ser camada `infra`
+- [x] Gerar a migração da tabela `users` com `npm run migration:create`, deixando o prefixo de timestamp para a ferramenta
+- [x] Escrever o `up` e o `down` da migração de `users` com as colunas `id`, `first_name`, `last_name`, `email`, `password_hash`, `verified_at`, `created_at` e `updated_at`, a chave primária `users_pkey` e a restrição `users_email_unique`
+- [x] Gerar a migração da tabela `user_activation_tokens` com `npm run migration:create`
+- [x] Escrever o `up` e o `down` dessa migração com as colunas `id`, `user_id_fk`, `token`, `expires_at`, `used_at` e `created_at`, a chave primária `user_activation_tokens_pkey`, a restrição `user_activation_tokens_token_unique`, o índice `user_activation_tokens_user_id_fk_idx` e a chave estrangeira `user_activation_tokens_user_id_fk_fkey` para `users(id)` com `ON DELETE CASCADE`
+- [x] Subir o compose local, aplicar as migrações com `npm run migration:up` e conferir tabelas, colunas e índices criados; validar o `down` revertendo e reaplicando
+- [x] Executar `npm run format:check` e `npm run lint:check` e corrigir o que apontarem
 
 ## Critérios de Aceitação
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@testcontainers/postgresql": "12.1.0",
         "@types/node": "26.1.0",
         "@types/nodemailer": "8.0.1",
+        "@types/pg": "8.21.0",
         "@types/react": "19.2.18",
         "@vitest/coverage-v8": "4.1.10",
         "dotenv-cli": "11.0.0",
@@ -3235,7 +3236,7 @@
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
       "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -3249,6 +3250,18 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -7498,7 +7511,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@testcontainers/postgresql": "12.1.0",
     "@types/node": "26.1.0",
     "@types/nodemailer": "8.0.1",
+    "@types/pg": "8.21.0",
     "@types/react": "19.2.18",
     "@vitest/coverage-v8": "4.1.10",
     "dotenv-cli": "11.0.0",

--- a/src/infra/database/connection.ts
+++ b/src/infra/database/connection.ts
@@ -1,0 +1,57 @@
+import { Pool, type PoolClient, type QueryResult, type QueryResultRow } from 'pg'
+
+export type PostgresConfig = Readonly<{
+  database: string
+  host: string
+  password: string
+  port: number
+  ssl: boolean
+  user: string
+}>
+
+export class Database {
+  private constructor(private readonly pool: Pool) {}
+
+  public static async connect(config: PostgresConfig): Promise<Database> {
+    const pool = new Pool({
+      database: config.database,
+      host: config.host,
+      password: config.password,
+      port: config.port,
+      ssl: config.ssl,
+      user: config.user
+    })
+
+    await pool.query('SELECT 1')
+
+    return new Database(pool)
+  }
+
+  public async query<T extends QueryResultRow>(
+    statement: string,
+    values?: unknown[]
+  ): Promise<QueryResult<T>> {
+    return this.pool.query<T>(statement, values)
+  }
+
+  public async transaction<T>(handler: (client: PoolClient) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect()
+
+    try {
+      await client.query('BEGIN')
+      const result = await handler(client)
+      await client.query('COMMIT')
+
+      return result
+    } catch (error) {
+      await client.query('ROLLBACK')
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  public async disconnect(): Promise<void> {
+    await this.pool.end()
+  }
+}

--- a/src/infra/database/migrations/1787173906871_create-users.sql
+++ b/src/infra/database/migrations/1787173906871_create-users.sql
@@ -1,0 +1,18 @@
+-- Up Migration
+
+CREATE TABLE users (
+  id CHAR(26) NOT NULL,
+  first_name VARCHAR(100) NOT NULL,
+  last_name VARCHAR(100) NOT NULL,
+  email VARCHAR(254) NOT NULL,
+  password_hash TEXT NOT NULL,
+  verified_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL,
+  CONSTRAINT users_pkey PRIMARY KEY (id),
+  CONSTRAINT users_email_unique UNIQUE (email)
+);
+
+-- Down Migration
+
+DROP TABLE users;

--- a/src/infra/database/migrations/1787173907053_create-user-activation-tokens.sql
+++ b/src/infra/database/migrations/1787173907053_create-user-activation-tokens.sql
@@ -1,0 +1,19 @@
+-- Up Migration
+
+CREATE TABLE user_activation_tokens (
+  id CHAR(26) NOT NULL,
+  user_id_fk CHAR(26) NOT NULL,
+  token CHAR(32) NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  used_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL,
+  CONSTRAINT user_activation_tokens_pkey PRIMARY KEY (id),
+  CONSTRAINT user_activation_tokens_token_unique UNIQUE (token),
+  CONSTRAINT user_activation_tokens_user_id_fk_fkey FOREIGN KEY (user_id_fk) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE INDEX user_activation_tokens_user_id_fk_idx ON user_activation_tokens (user_id_fk);
+
+-- Down Migration
+
+DROP TABLE user_activation_tokens;

--- a/src/infra/docker/compose.yml
+++ b/src/infra/docker/compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - '5432:5432'
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Resumo

Implementa a TASK-2 do `cadastro-de-usuarios`: a conexão com o PostgreSQL e as migrações que criam o esquema de `users` e `user_activation_tokens`.

- `src/infra/database/connection.ts`: classe `Database` sobre o `Pool` do `pg`, com `connect`, `query`, `transaction` (único `try-catch` da tarefa, permitido por ser camada `infra`) e `disconnect`. `transaction` retira um cliente do pool, emite `BEGIN`, roda o handler, `COMMIT` em sucesso e `ROLLBACK` em erro, sempre devolvendo o cliente ao pool.
- Migração `users`: colunas `id`, `first_name`, `last_name`, `email`, `password_hash`, `verified_at`, `created_at`, `updated_at`; PK `users_pkey`; UNIQUE `users_email_unique`.
- Migração `user_activation_tokens`: colunas `id`, `user_id_fk`, `token`, `expires_at`, `used_at`, `created_at`; PK `user_activation_tokens_pkey`; UNIQUE `user_activation_tokens_token_unique`; índice `user_activation_tokens_user_id_fk_idx`; FK `user_activation_tokens_user_id_fk_fkey` para `users(id)` com `ON DELETE CASCADE`.
- Correção do `compose.yml`: a imagem `postgres:18` recusa montar volume diretamente em `/var/lib/postgresql/data` (mudança de layout da própria imagem); o volume passou a ser montado em `/var/lib/postgresql`.
- Adiciona `@types/pg` (dentro do período de quarentena de 7 dias do `.npmrc`) para tipar o driver.

Esta é a base sobre a qual o repositório de usuários (TASK-5) e o orquestrador de testes (TASK-11) serão construídos.

## Referência

- TASK-2 em `.specs/cadastro-de-usuarios/tasks/task-2.md`
- PR empilhado sobre `feature/signup-task-1` (TASK-1)

## Plano de Teste

- [x] `docker compose -f src/infra/docker/compose.yml up -d`
- [x] `npm run migration:up` e conferência das tabelas, colunas, PK, UNIQUE, índice e FK via `psql`
- [x] `npm run migration:down` (duas vezes, revertendo as duas migrações) seguido de `npm run migration:up` novamente, confirmando os dois sentidos
- [x] `npm run format:check`
- [x] `npm run lint:check`
- [x] `npx tsc --noEmit` (sem novos erros; mantém apenas o erro pré-existente e fora de escopo em `src/main/plugins/problem.ts`)
- [x] `docker compose -f src/infra/docker/compose.yml down -v` para liberar portas e recursos