### PR TITLE
feat(code): contrato de controller, status 204 e adaptador do fastify

### DIFF
--- a/.specs/cadastro-de-usuarios/tasks.md
+++ b/.specs/cadastro-de-usuarios/tasks.md
@@ -8,7 +8,7 @@ A implementação é dividida em 6 ondas e 13 tarefas. A onda 1 estabelece a fun
 | :------ | :------------------------------------------------------------------------------- | :-------------- | -------------------------------------- |
 | TASK-1  | Fundação do projeto: dependências, apelidos de módulo e configuração de ambiente | ✅ Concluído    |                                        |
 | TASK-2  | Conexão com o PostgreSQL e migrações do esquema                                  | ✅ Concluído    | TASK-1                                 |
-| TASK-3  | Núcleo HTTP: contrato de controller, `204 No Content` e adaptador do Fastify     | 🔄 Em Progresso | TASK-1                                 |
+| TASK-3  | Núcleo HTTP: contrato de controller, `204 No Content` e adaptador do Fastify     | ✅ Concluído    | TASK-1                                 |
 | TASK-4  | Domínio: `Email`, `User`, `UserActivationToken` e o contrato `UserRepository`    | ✅ Concluído    | TASK-1                                 |
 | TASK-5  | Repositório de usuários em SQL                                                   | ✏️ Não Iniciado | TASK-2, TASK-4                         |
 | TASK-6  | Derivação de hash de senha com Argon2id                                          | 🔄 Em Progresso | TASK-1                                 |

--- a/.specs/cadastro-de-usuarios/tasks/task-3.md
+++ b/.specs/cadastro-de-usuarios/tasks/task-3.md
@@ -4,11 +4,11 @@ Os controllers da camada `application` não podem conhecer o Fastify, e o único
 
 ## Subtarefas
 
-- [ ] Criar `src/common/http/controller.ts` declarando os tipos `HTTPRequest` (com `body`, `params` e `query` como `unknown`) e `HTTPResponse` (com `body` opcional e `status`) e a interface `Controller`
-- [ ] Adicionar `NoContent = 204` ao enum `StatusCode` em `src/common/http/statuses.ts`
-- [ ] Adicionar a fábrica estática `Problem.from` em `src/common/http/problem.ts`, recebendo `title`, `detail` e `status` em um objeto e devolvendo um `Problem`
-- [ ] Criar `src/main/adapters/controller.ts` convertendo `FastifyRequest` em `HTTPRequest`, chamando `handle` e respondendo pelo `FastifyReply` com o status devolvido, sem enviar corpo quando o status for `204`
-- [ ] Executar `npm run format:check` e `npm run lint:check` e corrigir o que apontarem
+- [x] Criar `src/common/http/controller.ts` declarando os tipos `HTTPRequest` (com `body`, `params` e `query` como `unknown`) e `HTTPResponse` (com `body` opcional e `status`) e a interface `Controller`
+- [x] Adicionar `NoContent = 204` ao enum `StatusCode` em `src/common/http/statuses.ts`
+- [x] Adicionar a fábrica estática `Problem.from` em `src/common/http/problem.ts`, recebendo `title`, `detail` e `status` em um objeto e devolvendo um `Problem`
+- [x] Criar `src/main/adapters/controller.ts` convertendo `FastifyRequest` em `HTTPRequest`, chamando `handle` e respondendo pelo `FastifyReply` com o status devolvido, sem enviar corpo quando o status for `204`
+- [x] Executar `npm run format:check` e `npm run lint:check` e corrigir o que apontarem
 
 ## Critérios de Aceitação
 

--- a/src/common/http/controller.ts
+++ b/src/common/http/controller.ts
@@ -1,0 +1,16 @@
+import { type StatusCode } from '@common/http/statuses'
+
+export type HTTPRequest = Readonly<{
+  body: unknown
+  params: unknown
+  query: unknown
+}>
+
+export type HTTPResponse = Readonly<{
+  body?: unknown
+  status: StatusCode
+}>
+
+export interface Controller {
+  handle(request: HTTPRequest): Promise<HTTPResponse>
+}

--- a/src/common/http/problem.ts
+++ b/src/common/http/problem.ts
@@ -42,6 +42,10 @@ export class Problem extends Error {
     }
   }
 
+  public static from(details: Details): Problem {
+    return new Problem(details)
+  }
+
   public static fromZod(error: ZodError): Problem {
     const problem = new Problem({
       title: 'Request validation failed',

--- a/src/common/http/statuses.ts
+++ b/src/common/http/statuses.ts
@@ -1,4 +1,5 @@
 export enum StatusCode {
+  NoContent = 204,
   BadRequest = 400,
   InternalServerError = 500
 }

--- a/src/main/adapters/controller.ts
+++ b/src/main/adapters/controller.ts
@@ -1,0 +1,19 @@
+import { type FastifyRequest, type FastifyReply } from 'fastify'
+import { type Controller } from '@common/http/controller'
+import { StatusCode } from '@common/http/statuses'
+
+export function adaptController(controller: Controller) {
+  return async function handler(request: FastifyRequest, reply: FastifyReply) {
+    const response = await controller.handle({
+      body: request.body,
+      params: request.params,
+      query: request.query
+    })
+
+    if (response.status === StatusCode.NoContent) {
+      return reply.code(response.status).send()
+    }
+
+    return reply.code(response.status).send(response.body)
+  }
+}


### PR DESCRIPTION
## Resumo

Implementa a TASK-3 da funcionalidade de Cadastro de Usuários: o núcleo HTTP que desacopla os controllers da camada `application` do Fastify.

- Adiciona `src/common/http/controller.ts` com os tipos `HTTPRequest`, `HTTPResponse` e a interface `Controller`
- Adiciona `NoContent = 204` ao enum `StatusCode` em `src/common/http/statuses.ts`
- Adiciona a fábrica estática `Problem.from` em `src/common/http/problem.ts`
- Cria `src/main/adapters/controller.ts`, o adaptador que traduz um `Controller` em um handler do Fastify, respondendo `204 No Content` sem corpo quando aplicável (DEC-16, DEC-17)
- Marca a TASK-3 como concluída em `.specs/cadastro-de-usuarios/tasks.md` e `.specs/cadastro-de-usuarios/tasks/task-3.md`

Atende CA-32, CA-33 e CA-34 (base para as rotas de cadastro e ativação, que responderão `204 No Content` sem corpo e sem sessão).

PR empilhado sobre `feature/signup-task-1`.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint:check`
- [x] `npx tsc --noEmit` (único erro remanescente é pré-existente e fora de escopo em `src/main/plugins/problem.ts(6,7)`)
- Sem testes automatizados nesta tarefa — cobertura prevista nas TASK-12/TASK-13

🤖 Gerado com [Claude Code](https://claude.com/claude-code)