### PR TITLE
feat(code): interface hasher e implementação argon2id

### DIFF
--- a/.specs/cadastro-de-usuarios/tasks.md
+++ b/.specs/cadastro-de-usuarios/tasks.md
@@ -11,7 +11,7 @@ A implementação é dividida em 6 ondas e 13 tarefas. A onda 1 estabelece a fun
 | TASK-3  | Núcleo HTTP: contrato de controller, `204 No Content` e adaptador do Fastify     | 🔄 Em Progresso | TASK-1                                 |
 | TASK-4  | Domínio: `Email`, `User`, `UserActivationToken` e o contrato `UserRepository`    | ✅ Concluído    | TASK-1                                 |
 | TASK-5  | Repositório de usuários em SQL                                                   | ✏️ Não Iniciado | TASK-2, TASK-4                         |
-| TASK-6  | Derivação de hash de senha com Argon2id                                          | 🔄 Em Progresso | TASK-1                                 |
+| TASK-6  | Derivação de hash de senha com Argon2id                                          | ✅ Concluído    | TASK-1                                 |
 | TASK-7  | Template do e-mail de ativação e gateway SMTP                                    | ✏️ Não Iniciado | TASK-1                                 |
 | TASK-8  | Cadastro: caso de uso e controller de `POST /v1/auth/users`                      | ✏️ Não Iniciado | TASK-3, TASK-4, TASK-6, TASK-7         |
 | TASK-9  | Ativação: caso de uso e controller de `POST /v1/auth/users/activations`          | ✏️ Não Iniciado | TASK-3, TASK-4                         |

--- a/.specs/cadastro-de-usuarios/tasks/task-6.md
+++ b/.specs/cadastro-de-usuarios/tasks/task-6.md
@@ -4,11 +4,11 @@ A senha nunca é armazenada em texto puro e o caso de uso não pode conhecer o a
 
 ## Subtarefas
 
-- [ ] Criar `src/application/interfaces/hasher.ts` declarando a interface `Hasher` com o método `hash(plain: string): Promise<string>`
-- [ ] Criar `src/infra/security/argon2-hasher.ts` implementando `Hasher` com o `@node-rs/argon2` e o algoritmo Argon2id
-- [ ] Extrair os parâmetros de custo (19 MiB de memória, 2 iterações e paralelismo 1) em constantes nomeadas, sem valores mágicos no corpo do método
-- [ ] Conferir que o hash gerado embute os parâmetros de custo e preserva a senha exatamente como recebida, incluindo espaços nas bordas
-- [ ] Executar `npm run format:check` e `npm run lint:check` e corrigir o que apontarem
+- [x] Criar `src/application/interfaces/hasher.ts` declarando a interface `Hasher` com o método `hash(plain: string): Promise<string>`
+- [x] Criar `src/infra/security/argon2-hasher.ts` implementando `Hasher` com o `@node-rs/argon2` e o algoritmo Argon2id
+- [x] Extrair os parâmetros de custo (19 MiB de memória, 2 iterações e paralelismo 1) em constantes nomeadas, sem valores mágicos no corpo do método
+- [x] Conferir que o hash gerado embute os parâmetros de custo e preserva a senha exatamente como recebida, incluindo espaços nas bordas
+- [x] Executar `npm run format:check` e `npm run lint:check` e corrigir o que apontarem
 
 ## Critérios de Aceitação
 

--- a/src/application/interfaces/hasher.ts
+++ b/src/application/interfaces/hasher.ts
@@ -1,0 +1,3 @@
+export interface Hasher {
+  hash(plain: string): Promise<string>
+}

--- a/src/infra/security/argon2-hasher.ts
+++ b/src/infra/security/argon2-hasher.ts
@@ -1,0 +1,18 @@
+import { Algorithm, hash } from '@node-rs/argon2'
+
+import { type Hasher } from '@application/interfaces/hasher'
+
+const MEMORY_COST_IN_KIB = 19 * 1024
+const TIME_COST = 2
+const PARALLELISM = 1
+
+export class Argon2Hasher implements Hasher {
+  public async hash(plain: string): Promise<string> {
+    return hash(plain, {
+      algorithm: Algorithm.Argon2id,
+      memoryCost: MEMORY_COST_IN_KIB,
+      parallelism: PARALLELISM,
+      timeCost: TIME_COST
+    })
+  }
+}


### PR DESCRIPTION
## Resumo

Implementa a TASK-6 (Derivação de hash de senha com Argon2id):

- `src/application/interfaces/hasher.ts`: interface `Hasher` com `hash(plain: string): Promise<string>`.
- `src/infra/security/argon2-hasher.ts`: `Argon2Hasher`, implementação de `Hasher` usando `@node-rs/argon2` com algoritmo Argon2id e parâmetros de custo extraídos em constantes nomeadas (19 MiB de memória, 2 iterações, paralelismo 1).
- Marca as subtarefas de `task-6.md` como concluídas e atualiza o status de TASK-6 para "✅ Concluído" em `tasks.md`.

Referências: TASK-6 (`.specs/cadastro-de-usuarios/tasks/task-6.md`), CA-6 e CA-12 (`.specs/cadastro-de-usuarios/prd.md`).

PR empilhado sobre `feature/signup-task-1`.

## Test plan

- [x] `npm run format:check` — sem apontamentos
- [x] `npm run lint:check` — sem apontamentos
- [x] `npx tsc --noEmit` — nenhum erro novo (mantido apenas o erro pré-existente e fora de escopo em `src/main/plugins/problem.ts(6,7)`)
- [x] Verificação manual descartável com `npx tsx` confirmando:
  - hash muda a cada chamada (salt aleatório), mas ambos verificam a senha original via `verify` de `@node-rs/argon2`
  - o hash em formato PHC embute os parâmetros de custo (`m=19456,t=2,p=1`, equivalente a 19 MiB, 2 iterações, paralelismo 1)
  - senha com espaços nas bordas só verifica com os espaços presentes (não há trim)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)