### PR TITLE
feat(code): repositório sql de usuários

### DIFF
--- a/.specs/cadastro-de-usuarios/tasks.md
+++ b/.specs/cadastro-de-usuarios/tasks.md
@@ -10,7 +10,7 @@ A implementação é dividida em 6 ondas e 13 tarefas. A onda 1 estabelece a fun
 | TASK-2  | Conexão com o PostgreSQL e migrações do esquema                                  | ✅ Concluído    | TASK-1                                 |
 | TASK-3  | Núcleo HTTP: contrato de controller, `204 No Content` e adaptador do Fastify     | ✏️ Não Iniciado | TASK-1                                 |
 | TASK-4  | Domínio: `Email`, `User`, `UserActivationToken` e o contrato `UserRepository`    | ✅ Concluído    | TASK-1                                 |
-| TASK-5  | Repositório de usuários em SQL                                                   | ✏️ Não Iniciado | TASK-2, TASK-4                         |
+| TASK-5  | Repositório de usuários em SQL                                                   | 🔄 Em Progresso | TASK-2, TASK-4                         |
 | TASK-6  | Derivação de hash de senha com Argon2id                                          | ✏️ Não Iniciado | TASK-1                                 |
 | TASK-7  | Template do e-mail de ativação e gateway SMTP                                    | ✏️ Não Iniciado | TASK-1                                 |
 | TASK-8  | Cadastro: caso de uso e controller de `POST /v1/auth/users`                      | ✏️ Não Iniciado | TASK-3, TASK-4, TASK-6, TASK-7         |

--- a/.specs/cadastro-de-usuarios/tasks.md
+++ b/.specs/cadastro-de-usuarios/tasks.md
@@ -10,7 +10,7 @@ A implementação é dividida em 6 ondas e 13 tarefas. A onda 1 estabelece a fun
 | TASK-2  | Conexão com o PostgreSQL e migrações do esquema                                  | ✅ Concluído    | TASK-1                                 |
 | TASK-3  | Núcleo HTTP: contrato de controller, `204 No Content` e adaptador do Fastify     | ✏️ Não Iniciado | TASK-1                                 |
 | TASK-4  | Domínio: `Email`, `User`, `UserActivationToken` e o contrato `UserRepository`    | ✅ Concluído    | TASK-1                                 |
-| TASK-5  | Repositório de usuários em SQL                                                   | 🔄 Em Progresso | TASK-2, TASK-4                         |
+| TASK-5  | Repositório de usuários em SQL                                                   | ✅ Concluído    | TASK-2, TASK-4                         |
 | TASK-6  | Derivação de hash de senha com Argon2id                                          | ✏️ Não Iniciado | TASK-1                                 |
 | TASK-7  | Template do e-mail de ativação e gateway SMTP                                    | ✏️ Não Iniciado | TASK-1                                 |
 | TASK-8  | Cadastro: caso de uso e controller de `POST /v1/auth/users`                      | ✏️ Não Iniciado | TASK-3, TASK-4, TASK-6, TASK-7         |

--- a/.specs/cadastro-de-usuarios/tasks.md
+++ b/.specs/cadastro-de-usuarios/tasks.md
@@ -9,7 +9,7 @@ A implementação é dividida em 6 ondas e 13 tarefas. A onda 1 estabelece a fun
 | TASK-1  | Fundação do projeto: dependências, apelidos de módulo e configuração de ambiente | ✅ Concluído    |                                        |
 | TASK-2  | Conexão com o PostgreSQL e migrações do esquema                                  | 🔄 Em Progresso | TASK-1                                 |
 | TASK-3  | Núcleo HTTP: contrato de controller, `204 No Content` e adaptador do Fastify     | ✏️ Não Iniciado | TASK-1                                 |
-| TASK-4  | Domínio: `Email`, `User`, `UserActivationToken` e o contrato `UserRepository`    | 🔄 Em Progresso | TASK-1                                 |
+| TASK-4  | Domínio: `Email`, `User`, `UserActivationToken` e o contrato `UserRepository`    | ✅ Concluído    | TASK-1                                 |
 | TASK-5  | Repositório de usuários em SQL                                                   | ✏️ Não Iniciado | TASK-2, TASK-4                         |
 | TASK-6  | Derivação de hash de senha com Argon2id                                          | ✏️ Não Iniciado | TASK-1                                 |
 | TASK-7  | Template do e-mail de ativação e gateway SMTP                                    | ✏️ Não Iniciado | TASK-1                                 |

--- a/.specs/cadastro-de-usuarios/tasks/task-4.md
+++ b/.specs/cadastro-de-usuarios/tasks/task-4.md
@@ -4,13 +4,13 @@ A normalização do endereço de e-mail, a geração do identificador e dos meta
 
 ## Subtarefas
 
-- [ ] Criar `src/domain/value-objects/email.ts` com a classe `Email` e a fábrica `Email.create`, que converte todo o endereço para minúsculas e, quando o nome do usuário contém `+` em posição diferente da primeira, descarta tudo do `+` até o `@`, preservando pontos
-- [ ] Criar `src/domain/entities/user.ts` com a entidade `User` e a fábrica `User.create`, que gera o `id` em ULID com `ulidx`, define `createdAt` e `updatedAt` em UTC e nasce com `verifiedAt` nulo
-- [ ] Ordenar as propriedades de `User` conforme o padrão de código (identificador, propriedades em ordem alfabética, metadados) e marcar como `readonly` as que nunca são atualizadas
-- [ ] Criar `src/domain/entities/user-activation-token.ts` com `UserActivationToken.create(userId)`, que gera o `id` em ULID, o valor com 16 bytes de `crypto.randomBytes` serializados em hexadecimal minúsculo e o `expiresAt` 15 minutos após a criação, com a validade extraída em constante
-- [ ] Implementar `UserActivationToken.restore(properties)` para reconstruir a entidade a partir da linha do banco e `isUsable()`, que devolve verdadeiro apenas quando `usedAt` é nulo e `expiresAt` ainda não passou
-- [ ] Criar `src/domain/repositories/user.ts` com o tipo `CreateUserInput` e a interface `UserRepository`, declarando `create`, `findActivationToken` e `activateUser` com as assinaturas da TechSpec
-- [ ] Executar `npm run format:check` e `npm run lint:check` e corrigir o que apontarem
+- [x] Criar `src/domain/value-objects/email.ts` com a classe `Email` e a fábrica `Email.create`, que converte todo o endereço para minúsculas e, quando o nome do usuário contém `+` em posição diferente da primeira, descarta tudo do `+` até o `@`, preservando pontos
+- [x] Criar `src/domain/entities/user.ts` com a entidade `User` e a fábrica `User.create`, que gera o `id` em ULID com `ulidx`, define `createdAt` e `updatedAt` em UTC e nasce com `verifiedAt` nulo
+- [x] Ordenar as propriedades de `User` conforme o padrão de código (identificador, propriedades em ordem alfabética, metadados) e marcar como `readonly` as que nunca são atualizadas
+- [x] Criar `src/domain/entities/user-activation-token.ts` com `UserActivationToken.create(userId)`, que gera o `id` em ULID, o valor com 16 bytes de `crypto.randomBytes` serializados em hexadecimal minúsculo e o `expiresAt` 15 minutos após a criação, com a validade extraída em constante
+- [x] Implementar `UserActivationToken.restore(properties)` para reconstruir a entidade a partir da linha do banco e `isUsable()`, que devolve verdadeiro apenas quando `usedAt` é nulo e `expiresAt` ainda não passou
+- [x] Criar `src/domain/repositories/user.ts` com o tipo `CreateUserInput` e a interface `UserRepository`, declarando `create`, `findActivationToken` e `activateUser` com as assinaturas da TechSpec
+- [x] Executar `npm run format:check` e `npm run lint:check` e corrigir o que apontarem
 
 ## Critérios de Aceitação
 

--- a/.specs/cadastro-de-usuarios/tasks/task-5.md
+++ b/.specs/cadastro-de-usuarios/tasks/task-5.md
@@ -4,14 +4,14 @@ O `UserRepository` é o único ponto que sabe como a conta e o token chegam ao P
 
 ## Subtarefas
 
-- [ ] Criar `src/infra/database/repositories/user.ts` implementando `UserRepository` e recebendo a `Database` pelo construtor
-- [ ] Implementar `create` em transação: inserir em `users` com `ON CONFLICT (email) DO NOTHING RETURNING id` e, quando o `INSERT` não devolver linha, encerrar sem escrever e devolver `false`
-- [ ] Completar `create` inserindo a linha em `user_activation_tokens` quando a conta foi criada, reaproveitando o `created_at` da conta, e devolver `true`
-- [ ] Implementar `findActivationToken(value)` consultando `user_activation_tokens` pelo valor exato do token e devolvendo `UserActivationToken.restore(...)` ou `null`
-- [ ] Implementar `activateUser(token)` em transação: atualizar `used_at` com a guarda `used_at IS NULL` e `RETURNING user_id_fk`, devolvendo `false` quando nenhuma linha voltar
-- [ ] Completar `activateUser` atualizando `verified_at` e `updated_at` da conta devolvida pela primeira atualização e devolvendo `true`
-- [ ] Traduzir erros do PostgreSQL para `Problem` com `try-catch`, permitido apenas nesta camada
-- [ ] Executar `npm run format:check` e `npm run lint:check` e corrigir o que apontarem
+- [x] Criar `src/infra/database/repositories/user.ts` implementando `UserRepository` e recebendo a `Database` pelo construtor
+- [x] Implementar `create` em transação: inserir em `users` com `ON CONFLICT (email) DO NOTHING RETURNING id` e, quando o `INSERT` não devolver linha, encerrar sem escrever e devolver `false`
+- [x] Completar `create` inserindo a linha em `user_activation_tokens` quando a conta foi criada, reaproveitando o `created_at` da conta, e devolver `true`
+- [x] Implementar `findActivationToken(value)` consultando `user_activation_tokens` pelo valor exato do token e devolvendo `UserActivationToken.restore(...)` ou `null`
+- [x] Implementar `activateUser(token)` em transação: atualizar `used_at` com a guarda `used_at IS NULL` e `RETURNING user_id_fk`, devolvendo `false` quando nenhuma linha voltar
+- [x] Completar `activateUser` atualizando `verified_at` e `updated_at` da conta devolvida pela primeira atualização e devolvendo `true`
+- [x] Traduzir erros do PostgreSQL para `Problem` com `try-catch`, permitido apenas nesta camada
+- [x] Executar `npm run format:check` e `npm run lint:check` e corrigir o que apontarem
 
 ## Critérios de Aceitação
 

--- a/src/domain/entities/user-activation-token.ts
+++ b/src/domain/entities/user-activation-token.ts
@@ -1,0 +1,53 @@
+import { randomBytes } from 'node:crypto'
+import { ulid } from 'ulidx'
+
+const ACTIVATION_TOKEN_TTL_MS = 15 * 60 * 1000
+const ACTIVATION_TOKEN_BYTES = 16
+
+type RestoreTokenProperties = Readonly<{
+  createdAt: Date
+  expiresAt: Date
+  id: string
+  usedAt: Date | null
+  userId: string
+  value: string
+}>
+
+export class UserActivationToken {
+  public readonly id: string
+  public readonly userId: string
+  public readonly expiresAt: Date
+  public usedAt: Date | null
+  public readonly value: string
+  public readonly createdAt: Date
+
+  private constructor(properties: RestoreTokenProperties) {
+    this.id = properties.id
+    this.userId = properties.userId
+    this.expiresAt = properties.expiresAt
+    this.usedAt = properties.usedAt
+    this.value = properties.value
+    this.createdAt = properties.createdAt
+  }
+
+  public static create(userId: string): UserActivationToken {
+    const createdAt = new Date()
+
+    return new UserActivationToken({
+      id: ulid(),
+      userId,
+      expiresAt: new Date(createdAt.getTime() + ACTIVATION_TOKEN_TTL_MS),
+      usedAt: null,
+      value: randomBytes(ACTIVATION_TOKEN_BYTES).toString('hex'),
+      createdAt
+    })
+  }
+
+  public static restore(properties: RestoreTokenProperties): UserActivationToken {
+    return new UserActivationToken(properties)
+  }
+
+  public isUsable(): boolean {
+    return this.usedAt === null && this.expiresAt > new Date()
+  }
+}

--- a/src/domain/entities/user.ts
+++ b/src/domain/entities/user.ts
@@ -1,0 +1,55 @@
+import { type Email } from '@domain/value-objects/email'
+import { ulid } from 'ulidx'
+
+type CreateUserProperties = Readonly<{
+  email: Email
+  firstName: string
+  lastName: string
+  passwordHash: string
+}>
+
+export class User {
+  public readonly id: string
+  public readonly email: string
+  public readonly firstName: string
+  public readonly lastName: string
+  public readonly passwordHash: string
+  public verifiedAt: Date | null
+  public readonly createdAt: Date
+  public updatedAt: Date
+
+  private constructor(properties: {
+    id: string
+    email: string
+    firstName: string
+    lastName: string
+    passwordHash: string
+    verifiedAt: Date | null
+    createdAt: Date
+    updatedAt: Date
+  }) {
+    this.id = properties.id
+    this.email = properties.email
+    this.firstName = properties.firstName
+    this.lastName = properties.lastName
+    this.passwordHash = properties.passwordHash
+    this.verifiedAt = properties.verifiedAt
+    this.createdAt = properties.createdAt
+    this.updatedAt = properties.updatedAt
+  }
+
+  public static create(properties: CreateUserProperties): User {
+    const now = new Date()
+
+    return new User({
+      id: ulid(),
+      email: properties.email.value,
+      firstName: properties.firstName,
+      lastName: properties.lastName,
+      passwordHash: properties.passwordHash,
+      verifiedAt: null,
+      createdAt: now,
+      updatedAt: now
+    })
+  }
+}

--- a/src/domain/repositories/user.ts
+++ b/src/domain/repositories/user.ts
@@ -1,0 +1,13 @@
+import { type User } from '@domain/entities/user'
+import { type UserActivationToken } from '@domain/entities/user-activation-token'
+
+export type CreateUserInput = Readonly<{
+  token: UserActivationToken
+  user: User
+}>
+
+export interface UserRepository {
+  activateUser(token: UserActivationToken): Promise<boolean>
+  create(input: CreateUserInput): Promise<boolean>
+  findActivationToken(value: string): Promise<UserActivationToken | null>
+}

--- a/src/domain/value-objects/email.ts
+++ b/src/domain/value-objects/email.ts
@@ -1,0 +1,24 @@
+const ALIAS_SEPARATOR = '+'
+const DOMAIN_SEPARATOR = '@'
+
+export class Email {
+  public readonly value: string
+
+  private constructor(value: string) {
+    this.value = value
+  }
+
+  public static create(value: string): Email {
+    const lowercased = value.toLowerCase()
+    const [localPart, domain] = lowercased.split(DOMAIN_SEPARATOR)
+    const aliasIndex = localPart.indexOf(ALIAS_SEPARATOR)
+
+    if (aliasIndex <= 0) {
+      return new Email(lowercased)
+    }
+
+    const normalizedLocalPart = localPart.slice(0, aliasIndex)
+
+    return new Email(`${normalizedLocalPart}${DOMAIN_SEPARATOR}${domain}`)
+  }
+}

--- a/src/infra/database/repositories/user.ts
+++ b/src/infra/database/repositories/user.ts
@@ -1,0 +1,107 @@
+import { type PoolClient } from 'pg'
+import { Problem } from '@common/http/problem'
+import { UserActivationToken } from '@domain/entities/user-activation-token'
+import { type CreateUserInput, type UserRepository } from '@domain/repositories/user'
+import { type Database } from '@infra/database/connection'
+
+type ActivationTokenRow = Readonly<{
+  id: string
+  user_id_fk: string
+  token: string
+  expires_at: Date
+  used_at: Date | null
+  created_at: Date
+}>
+
+export class SQLUserRepository implements UserRepository {
+  public constructor(private readonly database: Database) {}
+
+  public async create(input: CreateUserInput): Promise<boolean> {
+    try {
+      return await this.database.transaction((client) => this.insertUser(client, input))
+    } catch {
+      throw Problem.internal()
+    }
+  }
+
+  public async findActivationToken(value: string): Promise<UserActivationToken | null> {
+    try {
+      const result = await this.database.query<ActivationTokenRow>(
+        `SELECT id, user_id_fk, token, expires_at, used_at, created_at
+         FROM user_activation_tokens
+         WHERE token = $1`,
+        [value]
+      )
+
+      const row = result.rows[0]
+
+      return row ? this.toActivationToken(row) : null
+    } catch {
+      throw Problem.internal()
+    }
+  }
+
+  public async activateUser(token: UserActivationToken): Promise<boolean> {
+    try {
+      return await this.database.transaction((client) => this.consumeToken(client, token))
+    } catch {
+      throw Problem.internal()
+    }
+  }
+
+  private async insertUser(client: PoolClient, input: CreateUserInput): Promise<boolean> {
+    const { token, user } = input
+
+    const result = await client.query<{ id: string }>(
+      `INSERT INTO users (id, first_name, last_name, email, password_hash, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $6)
+       ON CONFLICT (email) DO NOTHING
+       RETURNING id`,
+      [user.id, user.firstName, user.lastName, user.email, user.passwordHash, user.createdAt]
+    )
+
+    if (result.rowCount === 0) return false
+
+    await client.query(
+      `INSERT INTO user_activation_tokens (id, user_id_fk, token, expires_at, created_at)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [token.id, token.userId, token.value, token.expiresAt, user.createdAt]
+    )
+
+    return true
+  }
+
+  private async consumeToken(client: PoolClient, token: UserActivationToken): Promise<boolean> {
+    const now = new Date()
+
+    const result = await client.query<{ user_id_fk: string }>(
+      `UPDATE user_activation_tokens
+       SET used_at = $1
+       WHERE id = $2 AND used_at IS NULL
+       RETURNING user_id_fk`,
+      [now, token.id]
+    )
+
+    const row = result.rows[0]
+
+    if (!row) return false
+
+    await client.query('UPDATE users SET verified_at = $1, updated_at = $1 WHERE id = $2', [
+      now,
+      row.user_id_fk
+    ])
+
+    return true
+  }
+
+  private toActivationToken(row: ActivationTokenRow): UserActivationToken {
+    return UserActivationToken.restore({
+      id: row.id,
+      userId: row.user_id_fk,
+      value: row.token,
+      expiresAt: row.expires_at,
+      usedAt: row.used_at,
+      createdAt: row.created_at
+    })
+  }
+}


### PR DESCRIPTION
## Resumo

Implementa a TASK-5: o `UserRepository` em SQL sobre PostgreSQL, único ponto da base de código que sabe como a conta e o token de ativação chegam ao banco.

- `src/infra/database/repositories/user.ts`: `SQLUserRepository` implementa `create`, `findActivationToken` e `activateUser`, recebendo `Database` pelo construtor;
- `create` roda dentro de `Database.transaction`, insere em `users` com `ON CONFLICT (email) DO NOTHING RETURNING id`; quando o `INSERT` não devolve linha, encerra sem escrever e devolve `false`. Quando devolve, insere o token em `user_activation_tokens` reaproveitando o `created_at` da conta e devolve `true`;
- `findActivationToken` consulta `user_activation_tokens` pelo valor exato do token (`=`, sensível a caixa, sem `lower()`) e devolve `UserActivationToken.restore(...)` ou `null`;
- `activateUser` roda em transação: `UPDATE user_activation_tokens SET used_at = $1 WHERE id = $2 AND used_at IS NULL RETURNING user_id_fk`; sem linha devolvida, encerra e devolve `false`; com linha, atualiza `verified_at`/`updated_at` de `users` e devolve `true`;
- Erros do PostgreSQL são traduzidos para `Problem.internal()` via `try-catch`, único ponto permitido na camada `infra`.

## Dependências

Esta branch é o merge de `feature/signup-task-1-task-2` (conexão com PostgreSQL e migrações) e `feature/signup-task-1-task-4` (domínio: `Email`, `User`, `UserActivationToken`, `UserRepository`) sobre `feature/signup-task-1`. O PR usa `feature/signup-task-1-task-2` como base para minimizar o diff mostrado até que os PRs #29 (TASK-2) e #28 (TASK-4) sejam mergeados — depois disso o diff deste PR passa a mostrar apenas os arquivos da TASK-5.

## Test plan

Sem testes automatizados nesta tarefa (cobertura prevista para TASK-12/TASK-13). Validação manual realizada com script descartável (removido ao final) usando `Database.connect` + `SQLUserRepository`:

- [x] `npm install` (após o merge de TASK-2/TASK-4 no `package-lock.json`)
- [x] `docker compose -f src/infra/docker/compose.yml up -d` (PostgreSQL + MailCatcher locais)
- [x] `npm run migration:up` aplicou as duas migrações de TASK-2 (`users`, `user_activation_tokens`)
- [x] `create` chamado duas vezes com o mesmo e-mail: primeira `true`, segunda `false`; apenas 1 token gravado para a conta
- [x] `findActivationToken` com valor certo encontrou o token; com valor inexistente devolveu `null`
- [x] `activateUser` com token válido devolveu `true` e preencheu `verified_at`; chamado de novo com o mesmo token devolveu `false` (guarda `used_at IS NULL`)
- [x] `npm run format:check` — sem apontamentos
- [x] `npm run lint:check` — sem apontamentos
- [x] `npx tsc --noEmit` — nenhum erro novo (erro pré-existente e não relacionado permanece em `src/main/plugins/problem.ts(6,7)`)
- [x] `docker compose -f src/infra/docker/compose.yml down` — containers parados e portas liberadas